### PR TITLE
perf: put dirties in cache and move to database when commit

### DIFF
--- a/trie/database_types.go
+++ b/trie/database_types.go
@@ -30,6 +30,12 @@ func (m KvMap) Put(k, v []byte) {
 	m[sha256.Sum256(k)] = KV{k, v}
 }
 
+func (m KvMap) AddFrom(src KvMap) {
+	for k, v := range src {
+		m[k] = KV{v.K, v.V}
+	}
+}
+
 // Concat concatenates arrays of bytes
 func Concat(vs ...[]byte) []byte {
 	var b bytes.Buffer

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -124,8 +124,9 @@ func (t *ZkTrie) GetKey(kHashBytes []byte) []byte {
 // Committing flushes nodes from memory. Subsequent Get calls will load nodes
 // from the database.
 func (t *ZkTrie) Commit(LeafCallback) (common.Hash, int, error) {
-	// in current implmentation, every update of trie already writes into database
-	// so Commmit does nothing
+	// in current implementation, every update of trie writes into zkTrieDatabase cached map,
+	// so we need ZktrieDatabase.Commit() to flush them into storage
+	t.db.Commit()
 	return t.Hash(), 0, nil
 }
 

--- a/trie/zk_trie_database.go
+++ b/trie/zk_trie_database.go
@@ -15,22 +15,33 @@ import (
 type ZktrieDatabase struct {
 	db     *Database
 	prefix []byte
+
+	rawDirtiesCache KvMap
 }
 
 func NewZktrieDatabase(diskdb ethdb.KeyValueStore) *ZktrieDatabase {
-	return &ZktrieDatabase{db: NewDatabase(diskdb), prefix: []byte{}}
+	return &ZktrieDatabase{db: NewDatabase(diskdb), prefix: []byte{}, rawDirtiesCache: make(KvMap)}
 }
 
 // adhoc wrapper...
 func NewZktrieDatabaseFromTriedb(db *Database) *ZktrieDatabase {
 	db.Zktrie = true
-	return &ZktrieDatabase{db: db, prefix: []byte{}}
+	return &ZktrieDatabase{db: db, prefix: []byte{}, rawDirtiesCache: make(KvMap)}
 }
 
-// Put saves a key:value into the Storage
+// Commit commits the cached data into the Storage
+func (l *ZktrieDatabase) Commit() {
+	l.db.lock.Lock()
+	defer l.db.lock.Unlock()
+	if l.db.dirties != nil {
+		l.db.rawDirties.AddFrom(l.rawDirtiesCache)
+	}
+}
+
+// Put saves a key:value into the Cache
 func (l *ZktrieDatabase) Put(k, v []byte) error {
 	l.db.lock.Lock()
-	l.db.rawDirties.Put(Concat(l.prefix, k[:]), v)
+	l.rawDirtiesCache.Put(Concat(l.prefix, k[:]), v)
 	l.db.lock.Unlock()
 	return nil
 }
@@ -39,7 +50,10 @@ func (l *ZktrieDatabase) Put(k, v []byte) error {
 func (l *ZktrieDatabase) Get(key []byte) ([]byte, error) {
 	concatKey := Concat(l.prefix, key[:])
 	l.db.lock.RLock()
-	value, ok := l.db.rawDirties.Get(concatKey)
+	value, ok := l.rawDirtiesCache.Get(concatKey)
+	if !ok {
+		value, ok = l.db.rawDirties.Get(concatKey)
+	}
 	l.db.lock.RUnlock()
 	if ok {
 		return value, nil


### PR DESCRIPTION
## Descriptions
It is an optimization for handling the dirty data based on zk trie.

In current zktrie implementation, the dirty data produced by transactions will be directly stored in `trie.database` when executing `IntermediateRoot` function, which means these data will be flushed into diskDB eventually, even the corresponding block is not confirmed yet.

We introduced a cache map to store the dirties produced during the txs execution. And the cache will be flushed to database only when the trie is determined to be commit


