### PR TITLE
feat(miner): do not do ccc when commitNewWork

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -141,6 +141,7 @@ type environment struct {
 	receipts []*types.Receipt
 
 	// circuit capacity check related fields
+	skipCCC        bool                  // skip CCC when commitNewWork
 	traceEnv       *tracing.TraceEnv     // env for tracing
 	accRows        *types.RowConsumption // accumulated row consumption for a block
 	nextL1MsgIndex uint64                // next L1 queue index to be processed
@@ -877,6 +878,8 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 		w.current.discard()
 	}
 	w.current = env
+	// It does not need CCC for `commitNewWork`.
+	w.current.skipCCC = true
 	return nil
 }
 
@@ -938,8 +941,8 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction, coin
 	var traces *types.BlockTrace
 	var err error
 
-	// do not do CCC checks on follower nodes
-	if w.isRunning() {
+	// do not do CCC checks on follower nodes, or it is called from `commitNewWork`
+	if w.isRunning() && !env.skipCCC {
 		defer func(t0 time.Time) {
 			l2CommitTxTimer.Update(time.Since(t0))
 			if err != nil {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Worker always calls `commitNewWork` when new block is committed. During `commitNewWork`, it fetches the pending transactions from tx pool, and executes them. However, it would takes long time to finish this execution due to CCC, which may impact the block building process.
This PR make a little change in `commitTransaction`, that it will not call CCC during the process of `commitNewWork`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
