### PR TITLE
eth/downloader : avoid timer leak

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -995,11 +995,17 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, head uint64) e
 
 	// Start pulling the header chain skeleton until all is done
 	var (
-		skeleton = true  // Skeleton assembly phase or finishing up
-		pivoting = false // Whether the next request is pivot verification
-		ancestor = from
-		mode     = d.getMode()
+		skeleton           = true  // Skeleton assembly phase or finishing up
+		pivoting           = false // Whether the next request is pivot verification
+		ancestor           = from
+		mode               = d.getMode()
+		headerCheckTimer   = time.NewTimer(fsHeaderContCheck)
+		headerDelayedTimer = time.NewTimer(fsHeaderContCheck)
 	)
+
+	defer headerCheckTimer.Stop()
+	defer headerDelayedTimer.Stop()
+
 	for {
 		// Pull the next batch of headers, it either:
 		//   - Pivot check to see if the chain moved too far
@@ -1104,8 +1110,9 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, head uint64) e
 			// Don't abort header fetches while the pivot is downloading
 			if atomic.LoadInt32(&d.committed) == 0 && pivot <= from {
 				p.log.Debug("No headers, waiting for pivot commit")
+				headerCheckTimer.Reset(fsHeaderContCheck)
 				select {
-				case <-time.After(fsHeaderContCheck):
+				case <-headerCheckTimer.C:
 					continue
 				case <-d.cancelCh:
 					return errCanceled
@@ -1175,8 +1182,9 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, head uint64) e
 		// skeleton filling
 		if len(headers) == 0 && !progressed {
 			p.log.Trace("All headers delayed, waiting")
+			headerDelayedTimer.Reset(fsHeaderContCheck)
 			select {
-			case <-time.After(fsHeaderContCheck):
+			case <-headerDelayedTimer.C:
 				continue
 			case <-d.cancelCh:
 				return errCanceled


### PR DESCRIPTION
Due to the new mechanism this [pr 29596](https://github.com/ethereum/go-ethereum/pull/29596) is not merged, but it does solve the leakage problem

