### PR TITLE
all: use timer instead of time.After in loops, to avoid memleaks

### DIFF
--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -596,6 +596,9 @@ func (s *MatcherSession) deliverSections(bit uint, sections []uint64, bitsets []
 // of the session, any request in-flight need to be responded to! Empty responses
 // are fine though in that case.
 func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan *Retrieval) {
+	waitTimer := time.NewTimer(wait)
+	defer waitTimer.Stop()
+
 	for {
 		// Allocate a new bloom bit index to retrieve data for, stopping when done
 		bit, ok := s.allocateRetrieval()
@@ -604,6 +607,7 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 		}
 		// Bit allocated, throttle a bit if we're below our batch limit
 		if s.pendingSections(bit) < batch {
+			waitTimer.Reset(wait)
 			select {
 			case <-s.quit:
 				// Session terminating, we can't meaningfully service, abort
@@ -611,8 +615,8 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 				s.deliverSections(bit, []uint64{}, [][]byte{})
 				return
 
-			case <-time.After(wait):
-				// Throttling up, fetch whatever's available
+			case <-waitTimer.C:
+				// Throttling up, fetch whatever is available
 			}
 		}
 		// Allocate as much as we can handle and request servicing

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1258,6 +1258,7 @@ func (d *Downloader) processHeaders(origin uint64, td, ttd *big.Int, beaconMode 
 		rollback    uint64 // Zero means no rollback (fine as you can't unroll the genesis)
 		rollbackErr error
 		mode        = d.getMode()
+		timer       = time.NewTimer(time.Second)
 	)
 	defer func() {
 		if rollback > 0 {
@@ -1283,6 +1284,8 @@ func (d *Downloader) processHeaders(origin uint64, td, ttd *big.Int, beaconMode 
 	}()
 	// Wait for batches of headers to process
 	gotHeaders := false
+
+	defer timer.Stop()
 
 	for {
 		select {
@@ -1439,11 +1442,12 @@ func (d *Downloader) processHeaders(origin uint64, td, ttd *big.Int, beaconMode 
 				if mode == FullSync || mode == SnapSync {
 					// If we've reached the allowed number of pending headers, stall a bit
 					for d.queue.PendingBodies() >= maxQueuedHeaders || d.queue.PendingReceipts() >= maxQueuedHeaders {
+						timer.Reset(time.Second)
 						select {
 						case <-d.cancelCh:
 							rollbackErr = errCanceled
 							return errCanceled
-						case <-time.After(time.Second):
+						case <-timer.C:
 						}
 					}
 					// Otherwise insert the headers for content retrieval
@@ -1599,7 +1603,10 @@ func (d *Downloader) processSnapSyncContent() error {
 	var (
 		oldPivot *fetchResult   // Locked in pivot block, might change eventually
 		oldTail  []*fetchResult // Downloaded content after the pivot
+		timer    = time.NewTimer(time.Second)
 	)
+	defer timer.Stop()
+
 	for {
 		// Wait for the next batch of downloaded data to be available, and if the pivot
 		// block became stale, move the goalpost
@@ -1673,6 +1680,7 @@ func (d *Downloader) processSnapSyncContent() error {
 				oldPivot = P
 			}
 			// Wait for completion, occasionally checking for pivot staleness
+			timer.Reset(time.Second)
 			select {
 			case <-sync.done:
 				if sync.err != nil {
@@ -1683,7 +1691,7 @@ func (d *Downloader) processSnapSyncContent() error {
 				}
 				oldPivot = nil
 
-			case <-time.After(time.Second):
+			case <-timer.C:
 				oldTail = afterP
 				continue
 			}

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -541,10 +541,13 @@ func (s *Service) reportLatency(conn *connWrapper) error {
 		return err
 	}
 	// Wait for the pong request to arrive back
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
 	select {
 	case <-s.pongCh:
 		// Pong delivered, report the latency
-	case <-time.After(5 * time.Second):
+	case <-timer.C:
 		// Ping timeout, abort
 		return errors.New("ping timed out")
 	}

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -303,10 +303,13 @@ func (n *ExecNode) Stop() error {
 	go func() {
 		waitErr <- n.Cmd.Wait()
 	}()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
 	select {
 	case err := <-waitErr:
 		return err
-	case <-time.After(5 * time.Second):
+	case <-timer.C:
 		return n.Cmd.Process.Kill()
 	}
 }

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -65,8 +65,13 @@ func startStop(net *Network, quit chan struct{}, nodeCount int) {
 	if err != nil {
 		panic("Could not startup node network for mocker")
 	}
-	tick := time.NewTicker(10 * time.Second)
+	var (
+		tick  = time.NewTicker(10 * time.Second)
+		timer = time.NewTimer(3 * time.Second)
+	)
 	defer tick.Stop()
+	defer timer.Stop()
+
 	for {
 		select {
 		case <-quit:
@@ -80,11 +85,12 @@ func startStop(net *Network, quit chan struct{}, nodeCount int) {
 				return
 			}
 
+			timer.Reset(3 * time.Second)
 			select {
 			case <-quit:
 				log.Info("Terminating simulation loop")
 				return
-			case <-time.After(3 * time.Second):
+			case <-timer.C:
 			}
 
 			log.Debug("starting node", "id", id)

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -1032,11 +1032,14 @@ func (net *Network) Load(snap *Snapshot) error {
 		}
 	}
 
+	timeout := time.NewTimer(snapshotLoadTimeout)
+	defer timeout.Stop()
+
 	select {
 	// Wait until all connections from the snapshot are established.
 	case <-allConnected:
 	// Make sure that we do not wait forever.
-	case <-time.After(snapshotLoadTimeout):
+	case <-timeout.C:
 		return errors.New("snapshot connections not established")
 	}
 	return nil


### PR DESCRIPTION
[PR 29241](https://github.com/ethereum/go-ethereum/pull/29241)