### PR TITLE
Audit ToB 11: Fix handling failed L2 Transactions

### DIFF
--- a/miner/worker_l2.go
+++ b/miner/worker_l2.go
@@ -110,7 +110,7 @@ func (w *worker) fillTransactions(env *environment, l1Transactions types.Transac
 	var (
 		err                    error
 		circuitCapacityReached bool
-		skippedTxs             []*types.SkippedTransaction
+		skippedL1Txs           []*types.SkippedTransaction
 	)
 
 	defer func(env *environment) {
@@ -132,9 +132,9 @@ func (w *worker) fillTransactions(env *environment, l1Transactions types.Transac
 			}
 		}
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, l1Txs, env.header.BaseFee)
-		err, circuitCapacityReached, skippedTxs = w.commitTransactions(env, txs, env.header.Coinbase, interrupt)
+		err, circuitCapacityReached, skippedL1Txs = w.commitTransactions(env, txs, env.header.Coinbase, interrupt)
 		if err != nil || circuitCapacityReached {
-			return err, skippedTxs
+			return err, skippedL1Txs
 		}
 	}
 
@@ -159,7 +159,7 @@ func (w *worker) fillTransactions(env *environment, l1Transactions types.Transac
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, txList, env.header.BaseFee)
 		err, circuitCapacityReached, _ = w.commitTransactions(env, txs, w.coinbase, interrupt)
 		if err != nil || circuitCapacityReached {
-			return err, skippedTxs
+			return err, skippedL1Txs
 		}
 	}
 
@@ -167,7 +167,7 @@ func (w *worker) fillTransactions(env *environment, l1Transactions types.Transac
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, localTxs, env.header.BaseFee)
 		err, circuitCapacityReached, _ = w.commitTransactions(env, txs, env.header.Coinbase, interrupt)
 		if err != nil || circuitCapacityReached {
-			return err, skippedTxs
+			return err, skippedL1Txs
 		}
 	}
 	if len(remoteTxs) > 0 {
@@ -175,7 +175,7 @@ func (w *worker) fillTransactions(env *environment, l1Transactions types.Transac
 		err, _, _ = w.commitTransactions(env, txs, env.header.Coinbase, nil) // always return false
 	}
 
-	return err, skippedTxs
+	return err, skippedL1Txs
 }
 
 // generateWork generates a sealing block based on the given parameters.
@@ -299,7 +299,7 @@ func (w *worker) simulateL1Messages(genParams *generateParams, transactions type
 	}
 
 	txs := types.NewTransactionsByPriceAndNonce(env.signer, l1Txs, env.header.BaseFee)
-	_, _, skippedTxs := w.commitTransactions(env, txs, env.header.Coinbase, nil)
+	_, _, skippedL1Txs := w.commitTransactions(env, txs, env.header.Coinbase, nil)
 
-	return env.txs, skippedTxs, nil
+	return env.txs, skippedL1Txs, nil
 }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

An L2 transaction that causes a block row consumption error in the CCC may be added to
the skipped transaction list when it should not.

We now only add the transaction to skipped transactions list if it is an L1 transaction that should be skipped. 


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
