### PR TITLE
tracers: fix Morph fee-token tracing paths

### DIFF
--- a/core/token_gas.go
+++ b/core/token_gas.go
@@ -24,12 +24,15 @@ func startSystemCallTrace(evm *vm.EVM) func() {
 		return nil
 	}
 	tracer := evm.Config.Tracer
+	if tracer.OnSystemCallEnd == nil {
+		return nil
+	}
 	if tracer.OnSystemCallStartV2 != nil {
 		tracer.OnSystemCallStartV2(evm.GetVMContext())
-	} else if tracer.OnSystemCallStart != nil {
-		tracer.OnSystemCallStart()
+		return tracer.OnSystemCallEnd
 	}
-	if tracer.OnSystemCallEnd != nil {
+	if tracer.OnSystemCallStart != nil {
+		tracer.OnSystemCallStart()
 		return tracer.OnSystemCallEnd
 	}
 	return nil

--- a/core/token_gas.go
+++ b/core/token_gas.go
@@ -19,6 +19,22 @@ var (
 	maxGas uint64 = 200000
 )
 
+func startSystemCallTrace(evm *vm.EVM) func() {
+	if evm == nil || evm.Config.Tracer == nil {
+		return nil
+	}
+	tracer := evm.Config.Tracer
+	if tracer.OnSystemCallStartV2 != nil {
+		tracer.OnSystemCallStartV2(evm.GetVMContext())
+	} else if tracer.OnSystemCallStart != nil {
+		tracer.OnSystemCallStart()
+	}
+	if tracer.OnSystemCallEnd != nil {
+		return tracer.OnSystemCallEnd
+	}
+	return nil
+}
+
 // GetAltTokenBalanceHybrid returns the balance of an alt token using either storage slot or call method
 // If balanceSlot is zero hash, uses call method; otherwise uses storage slot method
 func (st *StateTransition) GetAltTokenBalanceHybrid(tokenID uint16, user common.Address) (*fees.TokenInfo, *big.Int, error) {
@@ -26,7 +42,7 @@ func (st *StateTransition) GetAltTokenBalanceHybrid(tokenID uint16, user common.
 	if err != nil {
 		return nil, nil, err
 	}
-	balance := new(big.Int)
+	var balance *big.Int
 	if !info.HasSlot {
 		balance, err = GetAltTokenBalanceByEVM(st.evm, info.TokenAddress, user)
 		if err != nil {
@@ -61,7 +77,7 @@ func GetAltTokenBalance(evm *vm.EVM, tokenID uint16, user common.Address) (*big.
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token address for token ID %d: %v", tokenID, err)
 	}
-	balance := new(big.Int)
+	var balance *big.Int
 	if info.HasSlot {
 		// balance slot exist
 		balance, _, err = fees.GetAltTokenBalanceFromSlot(evm.StateDB, info.TokenAddress, user, info.BalanceSlot)
@@ -89,9 +105,8 @@ func GetAltTokenBalanceByEVM(evm *vm.EVM, tokenAddress, userAddress common.Addre
 	// Create a message call context
 	sender := vm.AccountRef(userAddress)
 
-	if evm.Config.Tracer != nil && evm.Config.Tracer.OnSystemCallStartV2 != nil && evm.Config.Tracer.OnSystemCallEnd != nil {
-		evm.Config.Tracer.OnSystemCallStartV2(evm.GetVMContext())
-		defer evm.Config.Tracer.OnSystemCallEnd()
+	if endTrace := startSystemCallTrace(evm); endTrace != nil {
+		defer endTrace()
 	}
 
 	// Execute the call (using StaticCall since we're only reading state)
@@ -142,13 +157,14 @@ func transferAltTokenByEVM(evm *vm.EVM, tokenAddress, from, to common.Address, a
 	// Create a message call context
 	sender := vm.AccountRef(from)
 
-	if evm.Config.Tracer != nil && evm.Config.Tracer.OnSystemCallStartV2 != nil && evm.Config.Tracer.OnSystemCallEnd != nil {
-		evm.Config.Tracer.OnSystemCallStartV2(evm.GetVMContext())
-		defer evm.Config.Tracer.OnSystemCallEnd()
-	}
-
 	// Execute the call
-	ret, _, err := evm.Call(sender, tokenAddress, data, maxGas, big.NewInt(0))
+	var ret []byte
+	func() {
+		if endTrace := startSystemCallTrace(evm); endTrace != nil {
+			defer endTrace()
+		}
+		ret, _, err = evm.Call(sender, tokenAddress, data, maxGas, big.NewInt(0))
+	}()
 	if err != nil {
 		return fmt.Errorf("alt token transfer call failed: %v", err)
 	}

--- a/core/token_gas_test.go
+++ b/core/token_gas_test.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/morph-l2/go-ethereum/core/tracing"
+	"github.com/morph-l2/go-ethereum/core/vm"
+)
+
+func TestStartSystemCallTraceFallsBackToLegacyHook(t *testing.T) {
+	t.Parallel()
+
+	var starts, ends int
+	evm := &vm.EVM{
+		Config: vm.Config{
+			Tracer: &tracing.Hooks{
+				OnSystemCallStart: func() { starts++ },
+				OnSystemCallEnd:   func() { ends++ },
+			},
+		},
+	}
+
+	end := startSystemCallTrace(evm)
+	if starts != 1 {
+		t.Fatalf("unexpected legacy start count: %d", starts)
+	}
+	if end == nil {
+		t.Fatal("expected end hook")
+	}
+	end()
+	if ends != 1 {
+		t.Fatalf("unexpected end count: %d", ends)
+	}
+}
+
+func TestStartSystemCallTracePrefersV2Hook(t *testing.T) {
+	t.Parallel()
+
+	var legacyStarts, v2Starts int
+	evm := &vm.EVM{
+		Context: vm.BlockContext{
+			Time:        big.NewInt(0),
+			BlockNumber: big.NewInt(0),
+		},
+		Config: vm.Config{
+			Tracer: &tracing.Hooks{
+				OnSystemCallStart:   func() { legacyStarts++ },
+				OnSystemCallStartV2: func(*tracing.VMContext) { v2Starts++ },
+				OnSystemCallEnd:     func() {},
+			},
+		},
+	}
+
+	end := startSystemCallTrace(evm)
+	if end == nil {
+		t.Fatal("expected end hook")
+	}
+	if legacyStarts != 0 || v2Starts != 1 {
+		t.Fatalf("unexpected hook counts: legacy=%d v2=%d", legacyStarts, v2Starts)
+	}
+}

--- a/core/token_gas_test.go
+++ b/core/token_gas_test.go
@@ -60,3 +60,29 @@ func TestStartSystemCallTracePrefersV2Hook(t *testing.T) {
 		t.Fatalf("unexpected hook counts: legacy=%d v2=%d", legacyStarts, v2Starts)
 	}
 }
+
+func TestStartSystemCallTraceRequiresEndHook(t *testing.T) {
+	t.Parallel()
+
+	var legacyStarts, v2Starts int
+	evm := &vm.EVM{
+		Context: vm.BlockContext{
+			Time:        big.NewInt(0),
+			BlockNumber: big.NewInt(0),
+		},
+		Config: vm.Config{
+			Tracer: &tracing.Hooks{
+				OnSystemCallStart:   func() { legacyStarts++ },
+				OnSystemCallStartV2: func(*tracing.VMContext) { v2Starts++ },
+			},
+		},
+	}
+
+	end := startSystemCallTrace(evm)
+	if end != nil {
+		t.Fatal("expected nil end hook")
+	}
+	if legacyStarts != 0 || v2Starts != 0 {
+		t.Fatalf("unexpected hook counts without end hook: legacy=%d v2=%d", legacyStarts, v2Starts)
+	}
+}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -39,6 +39,7 @@ import (
 	"github.com/morph-l2/go-ethereum/core/tracing"
 	"github.com/morph-l2/go-ethereum/core/types"
 	"github.com/morph-l2/go-ethereum/core/vm"
+	"github.com/morph-l2/go-ethereum/crypto"
 	"github.com/morph-l2/go-ethereum/eth/tracers/logger"
 	"github.com/morph-l2/go-ethereum/ethdb"
 	"github.com/morph-l2/go-ethereum/internal/ethapi"
@@ -91,17 +92,118 @@ type Backend interface {
 type API struct {
 	backend            Backend
 	morphTracerWrapper morphTracerWrapper
-	addERC20Balance    func(evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int) error
+	addERC20Balance    func(statedb *state.StateDB, evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int) error
 }
 
 // NewAPI creates a new API definition for the tracing methods of the Ethereum service.
 func NewAPI(backend Backend, morphTracerWrapper morphTracerWrapper) *API {
 	api := &API{backend: backend, morphTracerWrapper: morphTracerWrapper}
-	// TODO
-	api.addERC20Balance = func(evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int) error {
+	api.addERC20Balance = addERC20Balance
+	return api
+}
+
+type balanceSlotTracer struct {
+	token common.Address
+	slots map[common.Hash]struct{}
+}
+
+func (t *balanceSlotTracer) OnOpcode(_ uint64, opcode byte, _ uint64, _ uint64, scope tracing.OpContext, _ []byte, _ int, err error) {
+	if err != nil || vm.OpCode(opcode) != vm.SLOAD || scope.Address() != t.token {
+		return
+	}
+	stack := scope.StackData()
+	if len(stack) == 0 {
+		return
+	}
+	t.slots[common.Hash(stack[len(stack)-1].Bytes32())] = struct{}{}
+}
+
+func addERC20Balance(statedb *state.StateDB, evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int) error {
+	if amount == nil || amount.Sign() == 0 {
 		return nil
 	}
-	return api
+	info, err := fees.GetTokenInfo(statedb, tokenID)
+	if err != nil {
+		return err
+	}
+	var slot common.Hash
+	if info.HasSlot {
+		_, slot, err = fees.GetAltTokenBalanceFromSlot(statedb, info.TokenAddress, addr, info.BalanceSlot)
+	} else {
+		slot, err = discoverERC20BalanceSlot(statedb, evm, info.TokenAddress, addr)
+	}
+	if err != nil {
+		return err
+	}
+	current := new(big.Int).SetBytes(statedb.GetState(info.TokenAddress, slot).Bytes())
+	statedb.SetState(info.TokenAddress, slot, common.BigToHash(new(big.Int).Add(current, amount)))
+	return nil
+}
+
+func discoverERC20BalanceSlot(statedb *state.StateDB, evm *vm.EVM, tokenAddress, user common.Address) (common.Hash, error) {
+	currentBalance, userSlots, err := traceERC20BalanceSlots(statedb, evm, tokenAddress, user)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	probe := deriveBalanceProbeAddress(tokenAddress, user)
+	_, probeSlots, err := traceERC20BalanceSlots(statedb, evm, tokenAddress, probe)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	for slot := range userSlots {
+		if _, seen := probeSlots[slot]; seen {
+			continue
+		}
+		ok, err := validateERC20BalanceSlot(statedb, evm, tokenAddress, user, currentBalance, slot)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		if ok {
+			return slot, nil
+		}
+	}
+	return common.Hash{}, fmt.Errorf("failed to discover ERC20 balance slot for token %s", tokenAddress.Hex())
+}
+
+func traceERC20BalanceSlots(statedb *state.StateDB, evm *vm.EVM, tokenAddress, user common.Address) (*big.Int, map[common.Hash]struct{}, error) {
+	probeTracer := &balanceSlotTracer{
+		token: tokenAddress,
+		slots: make(map[common.Hash]struct{}),
+	}
+	cfg := evm.Config
+	cfg.Tracer = &tracing.Hooks{OnOpcode: probeTracer.OnOpcode}
+	probeEVM := vm.NewEVM(evm.Context, evm.TxContext, statedb, evm.ChainConfig(), cfg)
+	balance, err := core.GetAltTokenBalanceByEVM(probeEVM, tokenAddress, user)
+	if err != nil {
+		return nil, nil, err
+	}
+	return balance, probeTracer.slots, nil
+}
+
+func validateERC20BalanceSlot(statedb *state.StateDB, evm *vm.EVM, tokenAddress, user common.Address, currentBalance *big.Int, slot common.Hash) (bool, error) {
+	snapshot := statedb.Snapshot()
+	defer statedb.RevertToSnapshot(snapshot)
+
+	current := new(big.Int).SetBytes(statedb.GetState(tokenAddress, slot).Bytes())
+	statedb.SetState(tokenAddress, slot, common.BigToHash(new(big.Int).Add(current, big.NewInt(1))))
+
+	balance, _, err := traceERC20BalanceSlots(statedb, evm, tokenAddress, user)
+	if err != nil {
+		return false, err
+	}
+	expected := new(big.Int).Add(new(big.Int).Set(currentBalance), big.NewInt(1))
+	return balance.Cmp(expected) == 0, nil
+}
+
+func deriveBalanceProbeAddress(tokenAddress, user common.Address) common.Address {
+	probe := common.BytesToAddress(crypto.Keccak256(tokenAddress.Bytes(), user.Bytes(), []byte("tracecall-balance-probe"))[12:])
+	if probe == (common.Address{}) || probe == user {
+		probe[19] ^= 0x01
+		if probe == user {
+			probe[18] ^= 0x01
+		}
+	}
+	return probe
 }
 
 type chainContext struct {
@@ -990,7 +1092,7 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message core
 			if err != nil {
 				return nil, err
 			}
-			if err := api.addERC20Balance(vmenv, message.FeeTokenID(), message.From(), erc20Amount); err != nil {
+			if err := api.addERC20Balance(statedb, vmenv, message.FeeTokenID(), message.From(), erc20Amount); err != nil {
 				return nil, err
 			}
 		}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -92,7 +92,7 @@ type Backend interface {
 type API struct {
 	backend            Backend
 	morphTracerWrapper morphTracerWrapper
-	addERC20Balance    func(statedb *state.StateDB, evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int) error
+	addERC20Balance    func(statedb *state.StateDB, evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int, mask *syntheticPrecreditMask) error
 }
 
 // NewAPI creates a new API definition for the tracing methods of the Ethereum service.
@@ -107,6 +107,17 @@ type balanceSlotTracer struct {
 	slots map[common.Hash]struct{}
 }
 
+type syntheticPrecreditMask struct {
+	active   bool
+	balances map[common.Address]*big.Int
+	storage  map[common.Address]map[common.Hash]common.Hash
+}
+
+type maskedTracingStateDB struct {
+	inner tracing.StateDB
+	mask  *syntheticPrecreditMask
+}
+
 func (t *balanceSlotTracer) OnOpcode(_ uint64, opcode byte, _ uint64, _ uint64, scope tracing.OpContext, _ []byte, _ int, err error) {
 	if err != nil || vm.OpCode(opcode) != vm.SLOAD || scope.Address() != t.token {
 		return
@@ -118,7 +129,7 @@ func (t *balanceSlotTracer) OnOpcode(_ uint64, opcode byte, _ uint64, _ uint64, 
 	t.slots[common.Hash(stack[len(stack)-1].Bytes32())] = struct{}{}
 }
 
-func addERC20Balance(statedb *state.StateDB, evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int) error {
+func addERC20Balance(statedb *state.StateDB, evm *vm.EVM, tokenID uint16, addr common.Address, amount *big.Int, mask *syntheticPrecreditMask) error {
 	if amount == nil || amount.Sign() == 0 {
 		return nil
 	}
@@ -135,9 +146,163 @@ func addERC20Balance(statedb *state.StateDB, evm *vm.EVM, tokenID uint16, addr c
 	if err != nil {
 		return err
 	}
-	current := new(big.Int).SetBytes(statedb.GetState(info.TokenAddress, slot).Bytes())
-	statedb.SetState(info.TokenAddress, slot, common.BigToHash(new(big.Int).Add(current, amount)))
+	current := statedb.GetState(info.TokenAddress, slot)
+	if mask != nil {
+		mask.addStorage(info.TokenAddress, slot, current)
+	}
+	statedb.SetState(info.TokenAddress, slot, common.BigToHash(new(big.Int).Add(new(big.Int).SetBytes(current.Bytes()), amount)))
 	return nil
+}
+
+func newSyntheticPrecreditMask() *syntheticPrecreditMask {
+	return &syntheticPrecreditMask{
+		active:   true,
+		balances: make(map[common.Address]*big.Int),
+		storage:  make(map[common.Address]map[common.Hash]common.Hash),
+	}
+}
+
+func (m *syntheticPrecreditMask) hasEntries() bool {
+	return m != nil && (len(m.balances) > 0 || len(m.storage) > 0)
+}
+
+func (m *syntheticPrecreditMask) addBalance(addr common.Address, balance *big.Int) {
+	if m == nil {
+		return
+	}
+	m.balances[addr] = new(big.Int).Set(balance)
+}
+
+func (m *syntheticPrecreditMask) addStorage(addr common.Address, slot common.Hash, value common.Hash) {
+	if m == nil {
+		return
+	}
+	if m.storage[addr] == nil {
+		m.storage[addr] = make(map[common.Hash]common.Hash)
+	}
+	m.storage[addr][slot] = value
+}
+
+func (m *syntheticPrecreditMask) originalBalance(addr common.Address) (*big.Int, bool) {
+	if m == nil || !m.active {
+		return nil, false
+	}
+	balance, ok := m.balances[addr]
+	if !ok {
+		return nil, false
+	}
+	return new(big.Int).Set(balance), true
+}
+
+func (m *syntheticPrecreditMask) originalStorage(addr common.Address, slot common.Hash) (common.Hash, bool) {
+	if m == nil || !m.active {
+		return common.Hash{}, false
+	}
+	value, ok := m.storage[addr][slot]
+	return value, ok
+}
+
+func (db *maskedTracingStateDB) GetBalance(addr common.Address) *big.Int {
+	if balance, ok := db.mask.originalBalance(addr); ok {
+		return balance
+	}
+	return db.inner.GetBalance(addr)
+}
+
+func (db *maskedTracingStateDB) GetNonce(addr common.Address) uint64 {
+	return db.inner.GetNonce(addr)
+}
+
+func (db *maskedTracingStateDB) GetCode(addr common.Address) []byte {
+	return db.inner.GetCode(addr)
+}
+
+func (db *maskedTracingStateDB) GetKeccakCodeHash(addr common.Address) common.Hash {
+	return db.inner.GetKeccakCodeHash(addr)
+}
+
+func (db *maskedTracingStateDB) GetPoseidonCodeHash(addr common.Address) common.Hash {
+	return db.inner.GetPoseidonCodeHash(addr)
+}
+
+func (db *maskedTracingStateDB) GetState(addr common.Address, key common.Hash) common.Hash {
+	if value, ok := db.mask.originalStorage(addr, key); ok {
+		return value
+	}
+	return db.inner.GetState(addr, key)
+}
+
+func (db *maskedTracingStateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	return db.inner.GetTransientState(addr, key)
+}
+
+func (db *maskedTracingStateDB) Exist(addr common.Address) bool {
+	return db.inner.Exist(addr)
+}
+
+func (db *maskedTracingStateDB) GetRefund() uint64 {
+	return db.inner.GetRefund()
+}
+
+func (db *maskedTracingStateDB) GetCodeSize(addr common.Address) uint64 {
+	return db.inner.GetCodeSize(addr)
+}
+
+func shouldMaskSyntheticPrecredits(config *TraceConfig) bool {
+	if config == nil || config.Tracer == nil {
+		return false
+	}
+	if *config.Tracer == "prestateTracer" {
+		return true
+	}
+	if *config.Tracer != "muxTracer" || len(config.TracerConfig) == 0 {
+		return false
+	}
+	var subtracers map[string]json.RawMessage
+	if err := json.Unmarshal(config.TracerConfig, &subtracers); err != nil {
+		return false
+	}
+	_, ok := subtracers["prestateTracer"]
+	return ok
+}
+
+func wrapSyntheticPrecreditHooks(hooks *tracing.Hooks, mask *syntheticPrecreditMask) *tracing.Hooks {
+	if hooks == nil || !mask.hasEntries() {
+		return hooks
+	}
+	base := hooks
+	wrapped := *base
+	wrapped.OnTxStart = func(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
+		if base.OnTxStart == nil {
+			return
+		}
+		envCopy := *env
+		envCopy.StateDB = &maskedTracingStateDB{inner: env.StateDB, mask: mask}
+		base.OnTxStart(&envCopy, tx, from)
+	}
+	wrapped.OnTxEnd = func(receipt *types.Receipt, err error) {
+		mask.active = false
+		if base.OnTxEnd != nil {
+			base.OnTxEnd(receipt, err)
+		}
+	}
+	wrapped.OnBalanceChange = func(addr common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+		if original, ok := mask.originalBalance(addr); ok {
+			prev = original
+		}
+		if base.OnBalanceChange != nil {
+			base.OnBalanceChange(addr, prev, new, reason)
+		}
+	}
+	wrapped.OnStorageChange = func(addr common.Address, slot common.Hash, prev, new common.Hash) {
+		if original, ok := mask.originalStorage(addr, slot); ok {
+			prev = original
+		}
+		if base.OnStorageChange != nil {
+			base.OnStorageChange(addr, slot, prev, new)
+		}
+	}
+	return &wrapped
 }
 
 func discoverERC20BalanceSlot(statedb *state.StateDB, evm *vm.EVM, tokenAddress, user common.Address) (common.Hash, error) {
@@ -197,7 +362,8 @@ func validateERC20BalanceSlot(statedb *state.StateDB, evm *vm.EVM, tokenAddress,
 
 func deriveBalanceProbeAddress(tokenAddress, user common.Address) common.Address {
 	probe := common.BytesToAddress(crypto.Keccak256(tokenAddress.Bytes(), user.Bytes(), []byte("tracecall-balance-probe"))[12:])
-	if probe == (common.Address{}) || probe == user {
+	var zero common.Address
+	if probe == zero || probe == user {
 		probe[19] ^= 0x01
 		if probe == user {
 			probe[18] ^= 0x01
@@ -1040,6 +1206,9 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message core
 	var (
 		tracer       *Tracer
 		err          error
+		execState    = statedb
+		hooks        *tracing.Hooks
+		mask         *syntheticPrecreditMask
 		structLogger *logger.StructLogger
 		timeout      = defaultTraceTimeout
 		usedGas      uint64
@@ -1062,9 +1231,34 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message core
 			return nil, err
 		}
 	}
-	tracingStateDB := state.NewHookedState(statedb, tracer.Hooks)
+	hooks = tracer.Hooks
+	if l1DataFee != nil && l1DataFee.Sign() > 0 && message.GasPrice().Cmp(big.NewInt(0)) == 0 {
+		if shouldMaskSyntheticPrecredits(config) {
+			execState = statedb.Copy()
+			mask = newSyntheticPrecreditMask()
+		}
+		if message.FeeTokenID() == 0 {
+			if mask != nil {
+				mask.addBalance(message.From(), execState.GetBalance(message.From()))
+			}
+			execState.AddBalance(message.From(), l1DataFee, tracing.BalanceChangeUnspecified)
+		} else {
+			probeEVM := vm.NewEVM(vmctx, txContext, execState, api.backend.ChainConfig(), vm.Config{NoBaseFee: true})
+			erc20Amount, err := fees.EthToAlt(execState, message.FeeTokenID(), l1DataFee)
+			if err != nil {
+				return nil, err
+			}
+			if err := api.addERC20Balance(execState, probeEVM, message.FeeTokenID(), message.From(), erc20Amount, mask); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if mask != nil {
+		hooks = wrapSyntheticPrecreditHooks(hooks, mask)
+	}
+	tracingStateDB := state.NewHookedState(execState, hooks)
 	// Run the transaction with tracing enabled.
-	vmenv := vm.NewEVM(vmctx, txContext, tracingStateDB, api.backend.ChainConfig(), vm.Config{Tracer: tracer.Hooks, NoBaseFee: true})
+	vmenv := vm.NewEVM(vmctx, txContext, tracingStateDB, api.backend.ChainConfig(), vm.Config{Tracer: hooks, NoBaseFee: true})
 
 	// Define a meaningful timeout of a single transaction trace
 	if config.Timeout != nil {
@@ -1083,23 +1277,9 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message core
 	}()
 	defer cancel()
 
-	// If gasPrice is 0, make sure that the account has sufficient balance to cover `l1DataFee`.
-	if message.GasPrice().Cmp(big.NewInt(0)) == 0 {
-		if message.FeeTokenID() == 0 {
-			statedb.AddBalance(message.From(), l1DataFee, tracing.BalanceChangeUnspecified)
-		} else {
-			erc20Amount, err := fees.EthToAlt(statedb, message.FeeTokenID(), l1DataFee)
-			if err != nil {
-				return nil, err
-			}
-			if err := api.addERC20Balance(statedb, vmenv, message.FeeTokenID(), message.From(), erc20Amount); err != nil {
-				return nil, err
-			}
-		}
-	}
 	// Call Prepare to clear out the statedb access list
-	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
-	_, err = core.ApplyTransactionWithEVM(message, api.backend.ChainConfig(), new(core.GasPool).AddGas(message.Gas()), statedb, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, vmenv)
+	execState.SetTxContext(txctx.TxHash, txctx.TxIndex)
+	_, err = core.ApplyTransactionWithEVM(message, api.backend.ChainConfig(), new(core.GasPool).AddGas(message.Gas()), execState, vmctx.BlockNumber, txctx.BlockHash, tx, &usedGas, vmenv)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/morph-l2/go-ethereum/core"
 	"github.com/morph-l2/go-ethereum/core/rawdb"
 	"github.com/morph-l2/go-ethereum/core/state"
+	"github.com/morph-l2/go-ethereum/core/tracing"
 	"github.com/morph-l2/go-ethereum/core/types"
 	"github.com/morph-l2/go-ethereum/core/vm"
 	"github.com/morph-l2/go-ethereum/crypto"
@@ -45,6 +46,7 @@ import (
 	"github.com/morph-l2/go-ethereum/params"
 	"github.com/morph-l2/go-ethereum/rollup/fees"
 	"github.com/morph-l2/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -623,7 +625,7 @@ func TestAddERC20BalanceDynamicSlotDiscovery(t *testing.T) {
 		GasPrice: big.NewInt(0),
 	}, statedb, params.TestChainConfig, vm.Config{NoBaseFee: true})
 
-	if err := addERC20Balance(statedb, evm, tokenID, user, big.NewInt(5)); err != nil {
+	if err := addERC20Balance(statedb, evm, tokenID, user, big.NewInt(5), nil); err != nil {
 		t.Fatalf("failed to add ERC20 balance: %v", err)
 	}
 	balance, err := core.GetAltTokenBalanceByEVM(evm, token, user)
@@ -633,6 +635,63 @@ func TestAddERC20BalanceDynamicSlotDiscovery(t *testing.T) {
 	if balance.Cmp(big.NewInt(12)) != 0 {
 		t.Fatalf("unexpected ERC20 balance, have %v want %v", balance, 12)
 	}
+}
+
+func TestSyntheticPrecreditMaskPreservesPrestateTracerView(t *testing.T) {
+	t.Parallel()
+
+	user := common.HexToAddress("0x100")
+	recipient := common.HexToAddress("0x101")
+	token := common.HexToAddress("0x200")
+	slot := fees.CalculateAltTokenBalanceSlot(user, common.Hash{})
+	original := common.BigToHash(big.NewInt(7))
+	synthetic := common.BigToHash(big.NewInt(12))
+
+	statedb := newTestStateDB(t, nil)
+	statedb.SetState(token, slot, synthetic)
+
+	var (
+		seenStart common.Hash
+		seenPrev  common.Hash
+		seenFinal common.Hash
+		seenState tracing.StateDB
+	)
+	baseHooks := &tracing.Hooks{
+		OnTxStart: func(env *tracing.VMContext, _ *types.Transaction, _ common.Address) {
+			seenState = env.StateDB
+			seenStart = env.StateDB.GetState(token, slot)
+		},
+		OnStorageChange: func(addr common.Address, key common.Hash, prev, _ common.Hash) {
+			if addr == token && key == slot {
+				seenPrev = prev
+			}
+		},
+		OnTxEnd: func(_ *types.Receipt, _ error) {
+			seenFinal = seenState.GetState(token, slot)
+		},
+	}
+	mask := newSyntheticPrecreditMask()
+	mask.addStorage(token, slot, original)
+	hooks := wrapSyntheticPrecreditHooks(baseHooks, mask)
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		To:       &recipient,
+		Value:    big.NewInt(0),
+		Gas:      params.TxGas,
+		GasPrice: big.NewInt(0),
+	})
+	hooks.OnTxStart(&tracing.VMContext{
+		BlockNumber: big.NewInt(1),
+		StateDB:     statedb,
+	}, tx, user)
+	hooks.OnStorageChange(token, slot, synthetic, original)
+	statedb.SetState(token, slot, original)
+	hooks.OnTxEnd(&types.Receipt{GasUsed: params.TxGas}, nil)
+
+	require.Equal(t, original, seenStart)
+	require.Equal(t, original, seenPrev)
+	require.Equal(t, original, seenFinal)
 }
 
 type Account struct {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -252,7 +252,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: nil,
-			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[]}`,
+			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[],"l1DataFee":"0x0"}`,
 		},
 		// Standard JSON trace upon the head, plain transfer.
 		{
@@ -264,7 +264,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: nil,
-			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[]}`,
+			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[],"l1DataFee":"0x0"}`,
 		},
 		// Upon the last state, default to the post block's state
 		{
@@ -275,7 +275,7 @@ func TestTraceCall(t *testing.T) {
 				Value: (*hexutil.Big)(new(big.Int).Add(big.NewInt(params.Ether), big.NewInt(100))),
 			},
 			config: nil,
-			expect: `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[]}`,
+			expect: `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[],"l1DataFee":"0x0"}`,
 		},
 		// Before the first transaction, should be failed
 		{
@@ -310,7 +310,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: nil,
-			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[]}`,
+			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[],"l1DataFee":"0x0"}`,
 		},
 		// Standard JSON trace upon the pending block
 		{
@@ -322,7 +322,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: nil,
-			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[]}`,
+			expect:    `{"gas":21000,"failed":false,"returnValue":"0x","structLogs":[],"l1DataFee":"0x0"}`,
 		},
 	}
 	for i, testspec := range testSuite {
@@ -332,7 +332,7 @@ func TestTraceCall(t *testing.T) {
 				t.Errorf("Expect error %v, get nothing", testspec.expectErr)
 				continue
 			}
-			if !reflect.DeepEqual(err.Error(), testspec.expectErr.Error()) {
+			if err.Error() != testspec.expectErr.Error() {
 				t.Errorf("Error mismatch, want %v, get %v", testspec.expectErr, err)
 			}
 		} else {
@@ -453,7 +453,7 @@ func TestTraceBlock(t *testing.T) {
 				t.Errorf("test %d, want error %v", i, tc.expectErr)
 				continue
 			}
-			if !reflect.DeepEqual(err, tc.expectErr) {
+			if err.Error() != tc.expectErr.Error() {
 				t.Errorf("test %d: error mismatch, want %v, get %v", i, tc.expectErr, err)
 			}
 			continue
@@ -592,6 +592,49 @@ func TestTracingWithOverrides(t *testing.T) {
 	}
 }
 
+func TestAddERC20BalanceDynamicSlotDiscovery(t *testing.T) {
+	t.Parallel()
+
+	tokenID := uint16(1)
+	user := common.HexToAddress("0x100")
+	token := common.HexToAddress("0x200")
+	statedb := newTestStateDB(t, nil)
+
+	// Runtime bytecode:
+	// balanceOf(address) => return sload(keccak256(abi.encode(address, 0)))
+	statedb.SetCode(token, common.FromHex("0x600435600052600060205260406000205460005260206000f3"))
+	setTestTokenInfo(statedb, tokenID, token, nil)
+
+	userSlot := fees.CalculateAltTokenBalanceSlot(user, common.Hash{})
+	statedb.SetState(token, userSlot, common.BigToHash(big.NewInt(7)))
+
+	evm := vm.NewEVM(vm.BlockContext{
+		CanTransfer: core.CanTransfer,
+		Transfer:    core.Transfer,
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		Coinbase:    common.Address{},
+		GasLimit:    30_000_000,
+		BlockNumber: big.NewInt(1),
+		Time:        big.NewInt(0),
+		Difficulty:  big.NewInt(0),
+		BaseFee:     big.NewInt(0),
+	}, vm.TxContext{
+		Origin:   user,
+		GasPrice: big.NewInt(0),
+	}, statedb, params.TestChainConfig, vm.Config{NoBaseFee: true})
+
+	if err := addERC20Balance(statedb, evm, tokenID, user, big.NewInt(5)); err != nil {
+		t.Fatalf("failed to add ERC20 balance: %v", err)
+	}
+	balance, err := core.GetAltTokenBalanceByEVM(evm, token, user)
+	if err != nil {
+		t.Fatalf("failed to read ERC20 balance: %v", err)
+	}
+	if balance.Cmp(big.NewInt(12)) != 0 {
+		t.Fatalf("unexpected ERC20 balance, have %v want %v", balance, 12)
+	}
+}
+
 type Account struct {
 	key  *ecdsa.PrivateKey
 	addr common.Address
@@ -632,4 +675,30 @@ func newStates(keys []common.Hash, vals []common.Hash) *map[common.Hash]common.H
 		m[keys[i]] = vals[i]
 	}
 	return &m
+}
+
+func newTestStateDB(t *testing.T, alloc core.GenesisAlloc) *state.StateDB {
+	t.Helper()
+
+	db := rawdb.NewMemoryDatabase()
+	block := (&core.Genesis{Config: params.TestChainConfig, Alloc: alloc}).MustCommit(db)
+	statedb, err := state.New(block.Root(), state.NewDatabase(db), nil)
+	if err != nil {
+		t.Fatalf("failed to create state db: %v", err)
+	}
+	return statedb
+}
+
+func setTestTokenInfo(statedb *state.StateDB, tokenID uint16, token common.Address, balanceSlot *common.Hash) {
+	baseSlot := fees.GetTokenInfoStructBaseSlot(tokenID)
+	statedb.SetState(fees.TokenRegistryAddress, fees.CalculateStructFieldSlot(baseSlot, 0), common.BytesToHash(common.LeftPadBytes(token.Bytes(), 32)))
+	if balanceSlot != nil {
+		slotPlusOne := new(big.Int).Add(new(big.Int).SetBytes(balanceSlot.Bytes()), big.NewInt(1))
+		statedb.SetState(fees.TokenRegistryAddress, fees.CalculateStructFieldSlot(baseSlot, 1), common.BigToHash(slotPlusOne))
+	}
+	var status common.Hash
+	status[30] = 18
+	status[31] = 1
+	statedb.SetState(fees.TokenRegistryAddress, fees.CalculateStructFieldSlot(baseSlot, 2), status)
+	statedb.SetState(fees.TokenRegistryAddress, fees.CalculateStructFieldSlot(baseSlot, 3), common.BigToHash(big.NewInt(1)))
 }

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -120,8 +120,9 @@ type jsTracer struct {
 	activePrecompiles []common.Address      // List of active precompiles at current block
 	traceStep         bool                  // True if tracer object exposes a `step()` method
 	traceFrame        bool                  // True if tracer object exposes the `enter()` and `exit()` methods
-	err               error                 // Any error that should stop tracing
-	obj               *goja.Object          // Trace object
+	systemCallDepth   int
+	err               error        // Any error that should stop tracing
+	obj               *goja.Object // Trace object
 
 	// Methods exposed by tracer
 	result goja.Callable
@@ -236,12 +237,14 @@ func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage, chainCo
 
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart: t.OnTxStart,
-			OnTxEnd:   t.OnTxEnd,
-			OnEnter:   t.OnEnter,
-			OnExit:    t.OnExit,
-			OnOpcode:  t.OnOpcode,
-			OnFault:   t.OnFault,
+			OnTxStart:           t.OnTxStart,
+			OnTxEnd:             t.OnTxEnd,
+			OnEnter:             t.OnEnter,
+			OnExit:              t.OnExit,
+			OnOpcode:            t.OnOpcode,
+			OnFault:             t.OnFault,
+			OnSystemCallStartV2: t.OnSystemCallStart,
+			OnSystemCallEnd:     t.OnSystemCallEnd,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -331,6 +334,9 @@ func (t *jsTracer) onStart(from common.Address, to common.Address, create bool, 
 
 // OnOpcode implements the Tracer interface to trace a single step of VM execution.
 func (t *jsTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+	if t.systemCallDepth > 0 {
+		return
+	}
 	if !t.traceStep {
 		return
 	}
@@ -356,6 +362,9 @@ func (t *jsTracer) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.
 
 // OnFault implements the Tracer interface to trace an execution fault
 func (t *jsTracer) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
+	if t.systemCallDepth > 0 {
+		return
+	}
 	if t.err != nil {
 		return
 	}
@@ -384,6 +393,9 @@ func (t *jsTracer) onEnd(output []byte, gasUsed uint64, err error, reverted bool
 
 // OnEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *jsTracer) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	if t.systemCallDepth > 0 {
+		return
+	}
 	if t.err != nil {
 		return
 	}
@@ -413,6 +425,9 @@ func (t *jsTracer) OnEnter(depth int, typ byte, from common.Address, to common.A
 // OnExit is called when EVM exits a scope, even if the scope didn't
 // execute any code.
 func (t *jsTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+	if t.systemCallDepth > 0 {
+		return
+	}
 	if t.err != nil {
 		return
 	}
@@ -453,6 +468,16 @@ func (t *jsTracer) GetResult() (json.RawMessage, error) {
 // Stop terminates execution of the tracer at the first opportune moment.
 func (t *jsTracer) Stop(err error) {
 	t.vm.Interrupt(err)
+}
+
+func (t *jsTracer) OnSystemCallStart(*tracing.VMContext) {
+	t.systemCallDepth++
+}
+
+func (t *jsTracer) OnSystemCallEnd() {
+	if t.systemCallDepth > 0 {
+		t.systemCallDepth--
+	}
 }
 
 // onError is called anytime the running JS code is interrupted

--- a/eth/tracers/js/goja_systemcall_test.go
+++ b/eth/tracers/js/goja_systemcall_test.go
@@ -1,0 +1,101 @@
+package js
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/core/tracing"
+	"github.com/morph-l2/go-ethereum/core/types"
+	"github.com/morph-l2/go-ethereum/core/vm"
+	"github.com/morph-l2/go-ethereum/eth/tracers"
+	"github.com/morph-l2/go-ethereum/params"
+)
+
+type jsTestStateDB struct{}
+
+func (jsTestStateDB) GetBalance(common.Address) *big.Int               { return new(big.Int) }
+func (jsTestStateDB) GetNonce(common.Address) uint64                   { return 0 }
+func (jsTestStateDB) GetCode(common.Address) []byte                    { return nil }
+func (jsTestStateDB) GetKeccakCodeHash(common.Address) common.Hash     { return common.Hash{} }
+func (jsTestStateDB) GetPoseidonCodeHash(common.Address) common.Hash   { return common.Hash{} }
+func (jsTestStateDB) GetState(common.Address, common.Hash) common.Hash { return common.Hash{} }
+func (jsTestStateDB) GetTransientState(common.Address, common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (jsTestStateDB) Exist(common.Address) bool         { return false }
+func (jsTestStateDB) GetRefund() uint64                 { return 0 }
+func (jsTestStateDB) GetCodeSize(common.Address) uint64 { return 0 }
+
+type jsTestScope struct{}
+
+func (jsTestScope) MemoryData() []byte       { return nil }
+func (jsTestScope) StackData() []uint256.Int { return nil }
+func (jsTestScope) Caller() common.Address   { return common.Address{} }
+func (jsTestScope) Address() common.Address  { return common.Address{} }
+func (jsTestScope) CallValue() *big.Int      { return new(big.Int) }
+func (jsTestScope) CallInput() []byte        { return nil }
+func (jsTestScope) ContractCode() []byte     { return nil }
+
+func TestJSTracerSkipsSystemCalls(t *testing.T) {
+	t.Parallel()
+
+	const code = `{
+		steps: 0,
+		enters: 0,
+		exits: 0,
+		step: function(log, db) { this.steps++; },
+		enter: function(frame) { this.enters++; },
+		exit: function(frame) { this.exits++; },
+		fault: function(log, db) {},
+		result: function(ctx, db) { return {steps: this.steps, enters: this.enters, exits: this.exits}; }
+	}`
+
+	tracer, err := newJsTracer(code, &tracers.Context{}, nil, params.TestChainConfig)
+	if err != nil {
+		t.Fatalf("failed to create js tracer: %v", err)
+	}
+	tx := types.NewTx(&types.LegacyTx{
+		To:       &common.Address{},
+		Gas:      21000,
+		GasPrice: big.NewInt(0),
+		Value:    big.NewInt(0),
+	})
+	env := &tracing.VMContext{
+		BlockNumber: big.NewInt(0),
+		Time:        0,
+		BaseFee:     big.NewInt(0),
+		Coinbase:    common.Address{},
+		StateDB:     jsTestStateDB{},
+	}
+	scope := jsTestScope{}
+
+	tracer.OnTxStart(env, tx, common.Address{})
+	tracer.OnSystemCallStartV2(env)
+	tracer.OnEnter(1, byte(vm.CALL), common.Address{}, common.Address{}, []byte{1, 2, 3, 4}, 21000, big.NewInt(0))
+	tracer.OnOpcode(0, 0x00, 1, 1, scope, nil, 1, nil)
+	tracer.OnExit(1, nil, 0, nil, false)
+	tracer.OnSystemCallEnd()
+
+	tracer.OnEnter(1, byte(vm.CALL), common.Address{}, common.Address{}, []byte{1, 2, 3, 4}, 21000, big.NewInt(0))
+	tracer.OnOpcode(1, 0x00, 1, 1, scope, nil, 1, nil)
+	tracer.OnExit(1, nil, 0, nil, false)
+
+	res, err := tracer.GetResult()
+	if err != nil {
+		t.Fatalf("failed to get trace result: %v", err)
+	}
+	var got struct {
+		Steps  int `json:"steps"`
+		Enters int `json:"enters"`
+		Exits  int `json:"exits"`
+	}
+	if err := json.Unmarshal(res, &got); err != nil {
+		t.Fatalf("failed to decode trace result: %v", err)
+	}
+	if got.Steps != 1 || got.Enters != 1 || got.Exits != 1 {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+}

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -236,9 +236,9 @@ type StructLogger struct {
 	structLogs []*StructLog
 	resultSize int
 
-	interrupt atomic.Bool // Atomic flag to signal execution interruption
-	reason    error       // Textual reason for the interruption
-	skip      bool        // skip processing hooks.
+	interrupt       atomic.Bool // Atomic flag to signal execution interruption
+	reason          error       // Textual reason for the interruption
+	systemCallDepth int         // skip visible processing hooks while inside system calls.
 }
 
 // NewStreamingStructLogger returns a new streaming logger.
@@ -307,7 +307,7 @@ func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope 
 		return
 	}
 	// Processing a system call.
-	if l.skip {
+	if l.systemCallDepth > 0 {
 		return
 	}
 	// check if already accumulated the size of the response.
@@ -406,7 +406,7 @@ func (l *StructLogger) OnExit(depth int, output []byte, gasUsed uint64, err erro
 	if depth != 0 {
 		return
 	}
-	if l.skip {
+	if l.systemCallDepth > 0 {
 		return
 	}
 	l.output = output
@@ -499,11 +499,13 @@ func (l *StructLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, 
 }
 
 func (l *StructLogger) OnSystemCallStart(env *tracing.VMContext) {
-	l.skip = true
+	l.systemCallDepth++
 }
 
 func (l *StructLogger) OnSystemCallEnd() {
-	l.skip = false
+	if l.systemCallDepth > 0 {
+		l.systemCallDepth--
+	}
 }
 
 func (l *StructLogger) OnTxEnd(receipt *types.Receipt, err error) {
@@ -558,10 +560,10 @@ func WriteLogs(writer io.Writer, logs []*types.Log) {
 }
 
 type mdLogger struct {
-	out  io.Writer
-	cfg  *Config
-	env  *tracing.VMContext
-	skip bool
+	out             io.Writer
+	cfg             *Config
+	env             *tracing.VMContext
+	systemCallDepth int
 }
 
 // NewMarkdownLogger creates a logger which outputs information in a format adapted
@@ -591,15 +593,17 @@ func (t *mdLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from
 }
 
 func (t *mdLogger) OnSystemCallStart(env *tracing.VMContext) {
-	t.skip = true
+	t.systemCallDepth++
 }
 
 func (t *mdLogger) OnSystemCallEnd() {
-	t.skip = false
+	if t.systemCallDepth > 0 {
+		t.systemCallDepth--
+	}
 }
 
 func (t *mdLogger) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
-	if t.skip {
+	if t.systemCallDepth > 0 {
 		return
 	}
 	if depth != 0 {
@@ -629,7 +633,7 @@ func (t *mdLogger) OnEnter(depth int, typ byte, from common.Address, to common.A
 }
 
 func (t *mdLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
-	if t.skip {
+	if t.systemCallDepth > 0 {
 		return
 	}
 	if depth == 0 {
@@ -643,7 +647,7 @@ func (t *mdLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, r
 
 // OnOpcode also tracks SLOAD/SSTORE ops to track storage change.
 func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
-	if t.skip {
+	if t.systemCallDepth > 0 {
 		return
 	}
 	stack := scope.StackData()
@@ -666,7 +670,7 @@ func (t *mdLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.
 }
 
 func (t *mdLogger) OnFault(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
-	if t.skip {
+	if t.systemCallDepth > 0 {
 		return
 	}
 	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -523,6 +523,8 @@ func (l *StructLogger) OnTxEnd(receipt *types.Receipt, err error) {
 }
 
 func (l *StructLogger) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	// Keep tracking affected accounts during system calls because UpdatedAccounts()
+	// feeds proof collection and fee-token helper calls can touch required accounts.
 	l.statesAffected[to] = struct{}{}
 	target, ok := types.ParseDelegation(l.env.StateDB.GetCode(to))
 	// if the target is a delegation, we need to trace the target

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -55,10 +55,11 @@ func (c *callFrame) Type() string {
 }
 
 type jsonLogger struct {
-	encoder *json.Encoder
-	cfg     *Config
-	env     *tracing.VMContext
-	hooks   *tracing.Hooks
+	encoder         *json.Encoder
+	cfg             *Config
+	env             *tracing.VMContext
+	hooks           *tracing.Hooks
+	systemCallDepth int
 }
 
 // NewJSONLogger creates a new EVM tracer that prints execution steps as JSON objects
@@ -69,11 +70,13 @@ func NewJSONLogger(cfg *Config, writer io.Writer) *tracing.Hooks {
 		l.cfg = &Config{}
 	}
 	l.hooks = &tracing.Hooks{
-		OnTxStart:         l.OnTxStart,
-		OnSystemCallStart: l.onSystemCallStart,
-		OnExit:            l.OnExit,
-		OnOpcode:          l.OnOpcode,
-		OnFault:           l.OnFault,
+		OnTxStart:           l.OnTxStart,
+		OnSystemCallStart:   l.onSystemCallStartLegacy,
+		OnSystemCallStartV2: l.OnSystemCallStart,
+		OnSystemCallEnd:     l.OnSystemCallEnd,
+		OnExit:              l.OnExit,
+		OnOpcode:            l.OnOpcode,
+		OnFault:             l.OnFault,
 	}
 	return l.hooks
 }
@@ -86,22 +89,30 @@ func NewJSONLoggerWithCallFrames(cfg *Config, writer io.Writer) *tracing.Hooks {
 		l.cfg = &Config{}
 	}
 	l.hooks = &tracing.Hooks{
-		OnTxStart:         l.OnTxStart,
-		OnSystemCallStart: l.onSystemCallStart,
-		OnEnter:           l.OnEnter,
-		OnExit:            l.OnExit,
-		OnOpcode:          l.OnOpcode,
-		OnFault:           l.OnFault,
+		OnTxStart:           l.OnTxStart,
+		OnSystemCallStart:   l.onSystemCallStartLegacy,
+		OnSystemCallStartV2: l.OnSystemCallStart,
+		OnSystemCallEnd:     l.OnSystemCallEnd,
+		OnEnter:             l.OnEnter,
+		OnExit:              l.OnExit,
+		OnOpcode:            l.OnOpcode,
+		OnFault:             l.OnFault,
 	}
 	return l.hooks
 }
 
 func (l *jsonLogger) OnFault(pc uint64, op byte, gas uint64, cost uint64, scope tracing.OpContext, depth int, err error) {
+	if l.systemCallDepth > 0 {
+		return
+	}
 	// TODO: Add rData to this interface as well
 	l.OnOpcode(pc, op, gas, cost, scope, nil, depth, err)
 }
 
 func (l *jsonLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+	if l.systemCallDepth > 0 {
+		return
+	}
 	memory := scope.MemoryData()
 	stack := scope.StackData()
 
@@ -127,18 +138,25 @@ func (l *jsonLogger) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracin
 	l.encoder.Encode(log)
 }
 
-func (l *jsonLogger) onSystemCallStart() {
-	// Process no events while in system call.
-	hooks := *l.hooks
-	*l.hooks = tracing.Hooks{
-		OnSystemCallEnd: func() {
-			*l.hooks = hooks
-		},
+func (l *jsonLogger) OnSystemCallStart(*tracing.VMContext) {
+	l.systemCallDepth++
+}
+
+func (l *jsonLogger) onSystemCallStartLegacy() {
+	l.systemCallDepth++
+}
+
+func (l *jsonLogger) OnSystemCallEnd() {
+	if l.systemCallDepth > 0 {
+		l.systemCallDepth--
 	}
 }
 
 // OnEnter is not enabled by default.
 func (l *jsonLogger) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+	if l.systemCallDepth > 0 {
+		return
+	}
 	frame := callFrame{
 		op:    vm.OpCode(typ),
 		From:  from,
@@ -153,6 +171,9 @@ func (l *jsonLogger) OnEnter(depth int, typ byte, from common.Address, to common
 }
 
 func (l *jsonLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+	if l.systemCallDepth > 0 {
+		return
+	}
 	type endLog struct {
 		Output  string              `json:"output"`
 		GasUsed math.HexOrDecimal64 `json:"gasUsed"`

--- a/eth/tracers/logger/logger_json_test.go
+++ b/eth/tracers/logger/logger_json_test.go
@@ -1,0 +1,73 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/core/tracing"
+	"github.com/morph-l2/go-ethereum/core/types"
+	"github.com/morph-l2/go-ethereum/core/vm"
+)
+
+type loggerTestStateDB struct{}
+
+func (loggerTestStateDB) GetBalance(common.Address) *big.Int               { return new(big.Int) }
+func (loggerTestStateDB) GetNonce(common.Address) uint64                   { return 0 }
+func (loggerTestStateDB) GetCode(common.Address) []byte                    { return nil }
+func (loggerTestStateDB) GetKeccakCodeHash(common.Address) common.Hash     { return common.Hash{} }
+func (loggerTestStateDB) GetPoseidonCodeHash(common.Address) common.Hash   { return common.Hash{} }
+func (loggerTestStateDB) GetState(common.Address, common.Hash) common.Hash { return common.Hash{} }
+func (loggerTestStateDB) GetTransientState(common.Address, common.Hash) common.Hash {
+	return common.Hash{}
+}
+func (loggerTestStateDB) Exist(common.Address) bool         { return false }
+func (loggerTestStateDB) GetRefund() uint64                 { return 0 }
+func (loggerTestStateDB) GetCodeSize(common.Address) uint64 { return 0 }
+
+type loggerTestScope struct{}
+
+func (loggerTestScope) MemoryData() []byte       { return nil }
+func (loggerTestScope) StackData() []uint256.Int { return nil }
+func (loggerTestScope) Caller() common.Address   { return common.Address{} }
+func (loggerTestScope) Address() common.Address  { return common.Address{} }
+func (loggerTestScope) CallValue() *big.Int      { return new(big.Int) }
+func (loggerTestScope) CallInput() []byte        { return nil }
+func (loggerTestScope) ContractCode() []byte     { return nil }
+
+func TestJSONLoggerSkipsSystemCallV2(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	hooks := NewJSONLogger(nil, &out)
+	tx := types.NewTx(&types.LegacyTx{
+		To:       &common.Address{},
+		Gas:      21000,
+		GasPrice: big.NewInt(0),
+		Value:    big.NewInt(0),
+	})
+	env := &tracing.VMContext{StateDB: loggerTestStateDB{}}
+	scope := loggerTestScope{}
+
+	hooks.OnTxStart(env, tx, common.Address{})
+	hooks.OnSystemCallStartV2(env)
+	hooks.OnOpcode(0, byte(vm.SLOAD), 1, 1, scope, nil, 0, nil)
+	hooks.OnSystemCallEnd()
+	hooks.OnOpcode(1, byte(vm.SLOAD), 1, 1, scope, nil, 0, nil)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("unexpected number of log lines: %q", out.String())
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("failed to decode log line: %v", err)
+	}
+	if entry["pc"] != float64(1) {
+		t.Fatalf("unexpected logged pc: %v", entry["pc"])
+	}
+}

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -54,6 +54,7 @@ type fourByteTracer struct {
 	reason            error          // Textual reason for the interruption
 	chainConfig       *params.ChainConfig
 	activePrecompiles []common.Address // Updated on CaptureStart based on given rules
+	systemCallDepth   int
 }
 
 // newFourByteTracer returns a native go tracer which collects
@@ -65,8 +66,10 @@ func newFourByteTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 	}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart: t.OnTxStart,
-			OnEnter:   t.OnEnter,
+			OnTxStart:           t.OnTxStart,
+			OnEnter:             t.OnEnter,
+			OnSystemCallStartV2: t.OnSystemCallStart,
+			OnSystemCallEnd:     t.OnSystemCallEnd,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -98,7 +101,7 @@ func (t *fourByteTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction
 // OnEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *fourByteTracer) OnEnter(depth int, opcode byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	// Skip if tracing was interrupted
-	if t.interrupt.Load() {
+	if t.interrupt.Load() || t.systemCallDepth > 0 {
 		return
 	}
 	if len(input) < 4 {
@@ -115,6 +118,16 @@ func (t *fourByteTracer) OnEnter(depth int, opcode byte, from common.Address, to
 		return
 	}
 	t.store(input[0:4], len(input)-4)
+}
+
+func (t *fourByteTracer) OnSystemCallStart(*tracing.VMContext) {
+	t.systemCallDepth++
+}
+
+func (t *fourByteTracer) OnSystemCallEnd() {
+	if t.systemCallDepth > 0 {
+		t.systemCallDepth--
+	}
 }
 
 // GetResult returns the json-encoded nested list of call traces, and any

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -113,13 +113,13 @@ type callFrameMarshaling struct {
 }
 
 type callTracer struct {
-	callstack []callFrame
-	config    callTracerConfig
-	gasLimit  uint64
-	depth     int
-	interrupt atomic.Bool // Atomic flag to signal execution interruption
-	reason    error       // Textual reason for the interruption
-	skip      bool
+	callstack       []callFrame
+	config          callTracerConfig
+	gasLimit        uint64
+	depth           int
+	interrupt       atomic.Bool // Atomic flag to signal execution interruption
+	reason          error       // Textual reason for the interruption
+	systemCallDepth int
 }
 
 type callTracerConfig struct {
@@ -161,7 +161,7 @@ func newCallTracerObject(ctx *tracers.Context, cfg json.RawMessage) (*callTracer
 
 // OnEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *callTracer) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
-	if t.skip {
+	if t.systemCallDepth > 0 {
 		return
 	}
 	t.depth = depth
@@ -191,7 +191,7 @@ func (t *callTracer) OnEnter(depth int, typ byte, from common.Address, to common
 // OnExit is called when EVM exits a scope, even if the scope didn't
 // execute any code.
 func (t *callTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
-	if t.skip {
+	if t.systemCallDepth > 0 {
 		return
 	}
 	if depth == 0 {
@@ -227,16 +227,10 @@ func (t *callTracer) captureEnd(output []byte, gasUsed uint64, err error, revert
 }
 
 func (t *callTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
-	if t.skip {
-		return
-	}
 	t.gasLimit = tx.Gas()
 }
 
 func (t *callTracer) OnTxEnd(receipt *types.Receipt, err error) {
-	if t.skip {
-		return
-	}
 	// Error happened during tx validation.
 	if err != nil {
 		return
@@ -251,15 +245,17 @@ func (t *callTracer) OnTxEnd(receipt *types.Receipt, err error) {
 }
 
 func (t *callTracer) OnSystemCall(env *tracing.VMContext) {
-	t.skip = true
+	t.systemCallDepth++
 }
 
 func (t *callTracer) OnSystemCallEnd() {
-	t.skip = false
+	if t.systemCallDepth > 0 {
+		t.systemCallDepth--
+	}
 }
 
 func (t *callTracer) OnLog(log *types.Log) {
-	if t.skip {
+	if t.systemCallDepth > 0 {
 		return
 	}
 	// Only logs need to be captured via opcode processing

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -144,10 +144,12 @@ func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 	ft := &flatCallTracer{tracer: t, ctx: ctx, config: config, chainConfig: chainConfig}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart: ft.OnTxStart,
-			OnTxEnd:   ft.OnTxEnd,
-			OnEnter:   ft.OnEnter,
-			OnExit:    ft.OnExit,
+			OnTxStart:           ft.OnTxStart,
+			OnTxEnd:             ft.OnTxEnd,
+			OnEnter:             ft.OnEnter,
+			OnExit:              ft.OnExit,
+			OnSystemCallStartV2: ft.OnSystemCallStart,
+			OnSystemCallEnd:     ft.OnSystemCallEnd,
 		},
 		Stop:      ft.Stop,
 		GetResult: ft.GetResult,
@@ -216,6 +218,20 @@ func (t *flatCallTracer) OnTxEnd(receipt *types.Receipt, err error) {
 		return
 	}
 	t.tracer.OnTxEnd(receipt, err)
+}
+
+func (t *flatCallTracer) OnSystemCallStart(env *tracing.VMContext) {
+	if t.interrupt.Load() {
+		return
+	}
+	t.tracer.OnSystemCall(env)
+}
+
+func (t *flatCallTracer) OnSystemCallEnd() {
+	if t.interrupt.Load() {
+		return
+	}
+	t.tracer.OnSystemCallEnd()
 }
 
 // GetResult returns an empty json object.

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -120,6 +120,7 @@ type flatCallTracer struct {
 	ctx               *tracers.Context // Holds tracer context data
 	interrupt         atomic.Bool      // Atomic flag to signal execution interruption
 	activePrecompiles []common.Address // Updated on tx start based on given rules
+	systemCallDepth   int
 }
 
 type flatCallTracerConfig struct {
@@ -158,7 +159,7 @@ func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 
 // OnEnter is called when EVM enters a new scope (via call, create or selfdestruct).
 func (t *flatCallTracer) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
-	if t.interrupt.Load() {
+	if t.interrupt.Load() || t.systemCallDepth > 0 {
 		return
 	}
 	t.tracer.OnEnter(depth, typ, from, to, input, gas, value)
@@ -176,7 +177,7 @@ func (t *flatCallTracer) OnEnter(depth int, typ byte, from common.Address, to co
 // OnExit is called when EVM exits a scope, even if the scope didn't
 // execute any code.
 func (t *flatCallTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
-	if t.interrupt.Load() {
+	if t.interrupt.Load() || t.systemCallDepth > 0 {
 		return
 	}
 	t.tracer.OnExit(depth, output, gasUsed, err, reverted)
@@ -224,12 +225,16 @@ func (t *flatCallTracer) OnSystemCallStart(env *tracing.VMContext) {
 	if t.interrupt.Load() {
 		return
 	}
+	t.systemCallDepth++
 	t.tracer.OnSystemCall(env)
 }
 
 func (t *flatCallTracer) OnSystemCallEnd() {
 	if t.interrupt.Load() {
 		return
+	}
+	if t.systemCallDepth > 0 {
+		t.systemCallDepth--
 	}
 	t.tracer.OnSystemCallEnd()
 }

--- a/eth/tracers/native/call_flat_test.go
+++ b/eth/tracers/native/call_flat_test.go
@@ -17,6 +17,7 @@
 package native_test
 
 import (
+	"encoding/json"
 	"errors"
 	"math/big"
 	"testing"
@@ -59,4 +60,37 @@ func TestCallFlatStop(t *testing.T) {
 	// check that the error is returned by GetResult
 	_, tracerError := tracer.GetResult()
 	require.Equal(t, stopError, tracerError)
+}
+
+func TestCallFlatIgnoresHiddenSystemCallFrames(t *testing.T) {
+	tracer, err := tracers.DefaultDirectory.New("flatCallTracer", &tracers.Context{}, nil, params.MainnetChainConfig)
+	require.NoError(t, err)
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		To:       &common.Address{},
+		Value:    big.NewInt(0),
+		Gas:      21000,
+		GasPrice: big.NewInt(0),
+		Data:     nil,
+	})
+
+	tracer.OnTxStart(&tracing.VMContext{BlockNumber: big.NewInt(0)}, tx, common.Address{})
+	tracer.OnEnter(0, byte(vm.CALL), common.Address{}, common.Address{}, nil, 21000, big.NewInt(0))
+
+	tracer.OnSystemCallStartV2(&tracing.VMContext{})
+	tracer.OnEnter(1, byte(vm.STATICCALL), common.Address{}, common.Address{}, nil, 1000, nil)
+	tracer.OnExit(1, nil, 0, nil, false)
+	tracer.OnSystemCallEnd()
+
+	tracer.OnExit(0, nil, 21000, nil, false)
+	tracer.OnTxEnd(&types.Receipt{GasUsed: 21000}, nil)
+
+	res, err := tracer.GetResult()
+	require.NoError(t, err)
+
+	var frames []map[string]any
+	require.NoError(t, json.Unmarshal(res, &frames))
+	require.Len(t, frames, 1)
+	require.Equal(t, float64(0), frames[0]["subtraces"])
 }

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -58,18 +58,22 @@ func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params
 	t := &muxTracer{names: names, tracers: objects}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart:       t.OnTxStart,
-			OnTxEnd:         t.OnTxEnd,
-			OnEnter:         t.OnEnter,
-			OnExit:          t.OnExit,
-			OnOpcode:        t.OnOpcode,
-			OnFault:         t.OnFault,
-			OnGasChange:     t.OnGasChange,
-			OnBalanceChange: t.OnBalanceChange,
-			OnNonceChange:   t.OnNonceChange,
-			OnCodeChange:    t.OnCodeChange,
-			OnStorageChange: t.OnStorageChange,
-			OnLog:           t.OnLog,
+			OnTxStart:           t.OnTxStart,
+			OnTxEnd:             t.OnTxEnd,
+			OnEnter:             t.OnEnter,
+			OnExit:              t.OnExit,
+			OnOpcode:            t.OnOpcode,
+			OnFault:             t.OnFault,
+			OnGasChange:         t.OnGasChange,
+			OnBalanceChange:     t.OnBalanceChange,
+			OnNonceChange:       t.OnNonceChange,
+			OnNonceChangeV2:     t.OnNonceChangeV2,
+			OnCodeChange:        t.OnCodeChange,
+			OnStorageChange:     t.OnStorageChange,
+			OnLog:               t.OnLog,
+			OnSystemCallStart:   t.OnSystemCallStart,
+			OnSystemCallStartV2: t.OnSystemCallStartV2,
+			OnSystemCallEnd:     t.OnSystemCallEnd,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -148,6 +152,16 @@ func (t *muxTracer) OnNonceChange(a common.Address, prev, new uint64) {
 	}
 }
 
+func (t *muxTracer) OnNonceChangeV2(a common.Address, prev, new uint64, reason tracing.NonceChangeReason) {
+	for _, t := range t.tracers {
+		if t.OnNonceChangeV2 != nil {
+			t.OnNonceChangeV2(a, prev, new, reason)
+		} else if t.OnNonceChange != nil {
+			t.OnNonceChange(a, prev, new)
+		}
+	}
+}
+
 func (t *muxTracer) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
 	for _, t := range t.tracers {
 		if t.OnCodeChange != nil {
@@ -168,6 +182,32 @@ func (t *muxTracer) OnLog(log *types.Log) {
 	for _, t := range t.tracers {
 		if t.OnLog != nil {
 			t.OnLog(log)
+		}
+	}
+}
+
+func (t *muxTracer) OnSystemCallStart() {
+	for _, t := range t.tracers {
+		if t.OnSystemCallStart != nil {
+			t.OnSystemCallStart()
+		}
+	}
+}
+
+func (t *muxTracer) OnSystemCallStartV2(env *tracing.VMContext) {
+	for _, t := range t.tracers {
+		if t.OnSystemCallStartV2 != nil {
+			t.OnSystemCallStartV2(env)
+		} else if t.OnSystemCallStart != nil {
+			t.OnSystemCallStart()
+		}
+	}
+}
+
+func (t *muxTracer) OnSystemCallEnd() {
+	for _, t := range t.tracers {
+		if t.OnSystemCallEnd != nil {
+			t.OnSystemCallEnd()
 		}
 	}
 }

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -335,10 +335,13 @@ func (t *prestateTracer) OnCodeChange(addr common.Address, prevCodeHash common.H
 }
 
 func (t *prestateTracer) OnStorageChange(addr common.Address, slot common.Hash, prev, _ common.Hash) {
-	if t.interrupt.Load() || t.env == nil || t.config.DisableStorage {
+	if t.interrupt.Load() || t.env == nil {
 		return
 	}
 	acc, _ := t.ensureAccount(addr)
+	if t.config.DisableStorage {
+		return
+	}
 	if _, ok := acc.Storage[slot]; ok {
 		return
 	}
@@ -355,10 +358,10 @@ func (t *prestateTracer) lookupAccount(addr common.Address) {
 // it to the prestate of the given contract. It ensures the account
 // exists in the prestate before accessing its storage.
 func (t *prestateTracer) lookupStorage(addr common.Address, key common.Hash) {
+	acc, _ := t.ensureAccount(addr)
 	if t.config.DisableStorage {
 		return
 	}
-	acc, _ := t.ensureAccount(addr)
 	if _, ok := acc.Storage[key]; ok {
 		return
 	}

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -50,7 +50,6 @@ type prestateTracer struct {
 	env         *tracing.VMContext
 	pre         stateMap
 	post        stateMap
-	create      bool
 	to          common.Address
 	config      prestateTracerConfig
 	chainConfig *params.ChainConfig
@@ -87,9 +86,13 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 	}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
-			OnTxStart: t.OnTxStart,
-			OnTxEnd:   t.OnTxEnd,
-			OnOpcode:  t.OnOpcode,
+			OnTxStart:       t.OnTxStart,
+			OnTxEnd:         t.OnTxEnd,
+			OnOpcode:        t.OnOpcode,
+			OnBalanceChange: t.OnBalanceChange,
+			OnNonceChangeV2: t.OnNonceChange,
+			OnCodeChange:    t.OnCodeChange,
+			OnStorageChange: t.OnStorageChange,
 		},
 		GetResult: t.GetResult,
 		Stop:      t.Stop,
@@ -294,27 +297,104 @@ func (t *prestateTracer) Stop(err error) {
 	t.interrupt.Store(true)
 }
 
-// lookupAccount fetches details of an account and adds it to the prestate
-// if it doesn't exist there.
-func (t *prestateTracer) lookupAccount(addr common.Address) {
-	if _, ok := t.pre[addr]; ok {
+func (t *prestateTracer) OnBalanceChange(addr common.Address, prev, _ *big.Int, reason tracing.BalanceChangeReason) {
+	if t.interrupt.Load() || t.env == nil {
 		return
 	}
-
-	t.pre[addr] = &account{
-		Balance: t.env.StateDB.GetBalance(addr),
-		Nonce:   t.env.StateDB.GetNonce(addr),
-		Code:    t.env.StateDB.GetCode(addr),
-		Storage: make(map[common.Hash]common.Hash),
+	acc, existed := t.ensureAccount(addr)
+	if !existed {
+		acc.Balance = new(big.Int).Set(prev)
+		acc.empty = isEmptyAccount(acc.Balance, acc.Nonce, acc.Code, acc.CodeHash)
 	}
 }
 
-// lookupStorage fetches the requested storage slot and adds
-// it to the prestate of the given contract. It assumes `lookupAccount`
-// has been performed on the contract before.
-func (t *prestateTracer) lookupStorage(addr common.Address, key common.Hash) {
-	if _, ok := t.pre[addr].Storage[key]; ok {
+func (t *prestateTracer) OnNonceChange(addr common.Address, prev, _ uint64, reason tracing.NonceChangeReason) {
+	if t.interrupt.Load() || t.env == nil {
 		return
 	}
-	t.pre[addr].Storage[key] = t.env.StateDB.GetState(addr, key)
+	acc, existed := t.ensureAccount(addr)
+	if !existed {
+		acc.Nonce = prev
+		acc.empty = isEmptyAccount(acc.Balance, acc.Nonce, acc.Code, acc.CodeHash)
+	}
+}
+
+func (t *prestateTracer) OnCodeChange(addr common.Address, prevCodeHash common.Hash, prevCode []byte, codeHash common.Hash, code []byte) {
+	if t.interrupt.Load() || t.env == nil {
+		return
+	}
+	acc, existed := t.ensureAccount(addr)
+	if !existed {
+		acc.Code = common.CopyBytes(prevCode)
+		acc.CodeHash = normalizeCodeHash(prevCodeHash)
+		if t.config.DisableCode {
+			acc.Code = nil
+		}
+		acc.empty = isEmptyAccount(acc.Balance, acc.Nonce, prevCode, normalizeCodeHash(prevCodeHash))
+	}
+}
+
+func (t *prestateTracer) OnStorageChange(addr common.Address, slot common.Hash, prev, _ common.Hash) {
+	if t.interrupt.Load() || t.env == nil || t.config.DisableStorage {
+		return
+	}
+	acc, _ := t.ensureAccount(addr)
+	if _, ok := acc.Storage[slot]; ok {
+		return
+	}
+	acc.Storage[slot] = prev
+}
+
+// lookupAccount fetches details of an account and adds it to the prestate
+// if it doesn't exist there.
+func (t *prestateTracer) lookupAccount(addr common.Address) {
+	t.ensureAccount(addr)
+}
+
+// lookupStorage fetches the requested storage slot and adds
+// it to the prestate of the given contract. It ensures the account
+// exists in the prestate before accessing its storage.
+func (t *prestateTracer) lookupStorage(addr common.Address, key common.Hash) {
+	if t.config.DisableStorage {
+		return
+	}
+	acc, _ := t.ensureAccount(addr)
+	if _, ok := acc.Storage[key]; ok {
+		return
+	}
+	acc.Storage[key] = t.env.StateDB.GetState(addr, key)
+}
+
+func (t *prestateTracer) ensureAccount(addr common.Address) (*account, bool) {
+	if acc, ok := t.pre[addr]; ok {
+		return acc, true
+	}
+	code := t.env.StateDB.GetCode(addr)
+	acc := &account{
+		Balance:  t.env.StateDB.GetBalance(addr),
+		Nonce:    t.env.StateDB.GetNonce(addr),
+		Code:     code,
+		CodeHash: normalizeCodeHash(t.env.StateDB.GetKeccakCodeHash(addr)),
+	}
+	acc.empty = isEmptyAccount(acc.Balance, acc.Nonce, code, acc.CodeHash)
+	if t.config.DisableCode {
+		acc.Code = nil
+	}
+	if !t.config.DisableStorage {
+		acc.Storage = make(map[common.Hash]common.Hash)
+	}
+	t.pre[addr] = acc
+	return acc, false
+}
+
+func normalizeCodeHash(codeHash common.Hash) *common.Hash {
+	if codeHash == (common.Hash{}) || codeHash == codehash.EmptyKeccakCodeHash {
+		return nil
+	}
+	h := codeHash
+	return &h
+}
+
+func isEmptyAccount(balance *big.Int, nonce uint64, code []byte, codeHash *common.Hash) bool {
+	return nonce == 0 && len(code) == 0 && codeHash == nil && (balance == nil || balance.Sign() == 0)
 }

--- a/eth/tracers/native/systemcall_prestate_test.go
+++ b/eth/tracers/native/systemcall_prestate_test.go
@@ -1,0 +1,225 @@
+package native
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/core/tracing"
+	"github.com/morph-l2/go-ethereum/core/types"
+	"github.com/morph-l2/go-ethereum/core/vm"
+	"github.com/morph-l2/go-ethereum/crypto"
+	"github.com/morph-l2/go-ethereum/crypto/codehash"
+	etracers "github.com/morph-l2/go-ethereum/eth/tracers"
+	"github.com/morph-l2/go-ethereum/params"
+)
+
+type tracerTestStateDB struct {
+	balances map[common.Address]*big.Int
+	nonces   map[common.Address]uint64
+	codes    map[common.Address][]byte
+	storage  map[common.Address]map[common.Hash]common.Hash
+}
+
+func (db *tracerTestStateDB) GetBalance(addr common.Address) *big.Int {
+	if bal, ok := db.balances[addr]; ok {
+		return new(big.Int).Set(bal)
+	}
+	return new(big.Int)
+}
+
+func (db *tracerTestStateDB) GetNonce(addr common.Address) uint64 {
+	return db.nonces[addr]
+}
+
+func (db *tracerTestStateDB) GetCode(addr common.Address) []byte {
+	return common.CopyBytes(db.codes[addr])
+}
+
+func (db *tracerTestStateDB) GetKeccakCodeHash(addr common.Address) common.Hash {
+	code := db.codes[addr]
+	if len(code) == 0 {
+		return codehash.EmptyKeccakCodeHash
+	}
+	return crypto.Keccak256Hash(code)
+}
+
+func (db *tracerTestStateDB) GetPoseidonCodeHash(common.Address) common.Hash {
+	return common.Hash{}
+}
+
+func (db *tracerTestStateDB) GetState(addr common.Address, key common.Hash) common.Hash {
+	if slots, ok := db.storage[addr]; ok {
+		return slots[key]
+	}
+	return common.Hash{}
+}
+
+func (db *tracerTestStateDB) GetTransientState(common.Address, common.Hash) common.Hash {
+	return common.Hash{}
+}
+
+func (db *tracerTestStateDB) Exist(addr common.Address) bool {
+	if bal := db.GetBalance(addr); bal.Sign() != 0 {
+		return true
+	}
+	if db.GetNonce(addr) != 0 || len(db.codes[addr]) != 0 {
+		return true
+	}
+	return len(db.storage[addr]) != 0
+}
+
+func (db *tracerTestStateDB) GetRefund() uint64 {
+	return 0
+}
+
+func (db *tracerTestStateDB) GetCodeSize(addr common.Address) uint64 {
+	return uint64(len(db.codes[addr]))
+}
+
+func newTracerTestStateDB() *tracerTestStateDB {
+	return &tracerTestStateDB{
+		balances: make(map[common.Address]*big.Int),
+		nonces:   make(map[common.Address]uint64),
+		codes:    make(map[common.Address][]byte),
+		storage:  make(map[common.Address]map[common.Hash]common.Hash),
+	}
+}
+
+func newPrestateTestTracer(cfg prestateTracerConfig, db *tracerTestStateDB) *prestateTracer {
+	return &prestateTracer{
+		env: &tracing.VMContext{
+			BlockNumber: big.NewInt(0),
+			Time:        0,
+			StateDB:     db,
+		},
+		pre:         stateMap{},
+		post:        stateMap{},
+		config:      cfg,
+		chainConfig: params.TestChainConfig,
+		created:     make(map[common.Address]bool),
+		deleted:     make(map[common.Address]bool),
+	}
+}
+
+func TestPrestateTracerLookupStorageCreatesAccount(t *testing.T) {
+	t.Parallel()
+
+	db := newTracerTestStateDB()
+	addr := common.HexToAddress("0x100")
+	slot := common.HexToHash("0x1")
+	value := common.HexToHash("0x2")
+	db.codes[addr] = []byte{0x60, 0x00}
+	db.storage[addr] = map[common.Hash]common.Hash{slot: value}
+
+	tracer := newPrestateTestTracer(prestateTracerConfig{}, db)
+	tracer.lookupStorage(addr, slot)
+
+	if tracer.pre[addr] == nil {
+		t.Fatalf("expected account to be added to prestate")
+	}
+	if got := tracer.pre[addr].Storage[slot]; got != value {
+		t.Fatalf("unexpected storage value, have %s want %s", got, value)
+	}
+}
+
+func TestPrestateTracerOnStorageChangeUsesPreviousValue(t *testing.T) {
+	t.Parallel()
+
+	db := newTracerTestStateDB()
+	addr := common.HexToAddress("0x200")
+	slot := common.HexToHash("0x3")
+	prev := common.HexToHash("0x4")
+	next := common.HexToHash("0x5")
+	db.codes[addr] = []byte{0x60, 0x00}
+	db.storage[addr] = map[common.Hash]common.Hash{slot: next}
+
+	tracer := newPrestateTestTracer(prestateTracerConfig{}, db)
+	tracer.OnStorageChange(addr, slot, prev, next)
+
+	if got := tracer.pre[addr].Storage[slot]; got != prev {
+		t.Fatalf("unexpected prestate slot value, have %s want %s", got, prev)
+	}
+}
+
+func TestPrestateTracerOnBalanceChangeUsesPreviousBalance(t *testing.T) {
+	t.Parallel()
+
+	db := newTracerTestStateDB()
+	addr := common.HexToAddress("0x300")
+	db.balances[addr] = big.NewInt(9)
+
+	tracer := newPrestateTestTracer(prestateTracerConfig{}, db)
+	tracer.OnBalanceChange(addr, big.NewInt(4), big.NewInt(9), tracing.BalanceChangeTransfer)
+
+	if got := tracer.pre[addr].Balance; got.Cmp(big.NewInt(4)) != 0 {
+		t.Fatalf("unexpected prestate balance, have %v want %v", got, 4)
+	}
+}
+
+func TestFourByteTracerSkipsSystemCalls(t *testing.T) {
+	t.Parallel()
+
+	tracer, err := newFourByteTracer(nil, nil, params.TestChainConfig)
+	if err != nil {
+		t.Fatalf("failed to create tracer: %v", err)
+	}
+	tx := types.NewTx(&types.LegacyTx{
+		To:       &common.Address{},
+		Gas:      21000,
+		GasPrice: big.NewInt(0),
+		Value:    big.NewInt(0),
+	})
+	tracer.OnTxStart(&tracing.VMContext{BlockNumber: big.NewInt(0)}, tx, common.Address{})
+
+	systemInput := append(common.FromHex("0x70a08231"), make([]byte, 32)...)
+	userInput := append(common.FromHex("0xa9059cbb"), make([]byte, 64)...)
+
+	tracer.OnSystemCallStartV2(&tracing.VMContext{})
+	tracer.OnEnter(1, byte(vm.CALL), common.Address{}, common.HexToAddress("0x1111"), systemInput, 0, big.NewInt(0))
+	tracer.OnSystemCallEnd()
+	tracer.OnEnter(1, byte(vm.CALL), common.Address{}, common.HexToAddress("0x2222"), userInput, 0, big.NewInt(0))
+
+	res, err := tracer.GetResult()
+	if err != nil {
+		t.Fatalf("failed to get trace result: %v", err)
+	}
+	var ids map[string]int
+	if err := json.Unmarshal(res, &ids); err != nil {
+		t.Fatalf("failed to decode trace result: %v", err)
+	}
+	if len(ids) != 1 || ids["0xa9059cbb-64"] != 1 {
+		t.Fatalf("unexpected 4byte result: %v", ids)
+	}
+}
+
+func TestMuxTracerForwardsSystemCallsAndNonceChangeV2(t *testing.T) {
+	t.Parallel()
+
+	var (
+		systemStarts int
+		systemEnds   int
+		nonceV2Calls int
+	)
+	sub := &etracers.Tracer{
+		Hooks: &tracing.Hooks{
+			OnSystemCallStartV2: func(*tracing.VMContext) { systemStarts++ },
+			OnSystemCallEnd:     func() { systemEnds++ },
+			OnNonceChangeV2: func(common.Address, uint64, uint64, tracing.NonceChangeReason) {
+				nonceV2Calls++
+			},
+		},
+		GetResult: func() (json.RawMessage, error) { return json.RawMessage(`{}`), nil },
+		Stop:      func(error) {},
+	}
+	mux := &muxTracer{tracers: []*etracers.Tracer{sub}}
+
+	mux.OnSystemCallStartV2(&tracing.VMContext{})
+	mux.OnSystemCallEnd()
+	mux.OnNonceChangeV2(common.Address{}, 1, 2, tracing.NonceChangeUnspecified)
+
+	if systemStarts != 1 || systemEnds != 1 || nonceV2Calls != 1 {
+		t.Fatalf("unexpected forwarded counts: starts=%d ends=%d nonceV2=%d", systemStarts, systemEnds, nonceV2Calls)
+	}
+}


### PR DESCRIPTION
## Summary
- fix Morph fee-token system-call handling across native, JSON, and JS tracers so user-visible traces stop leaking internal fee-token calls
- repair `prestateTracer` and `muxTracer` hook wiring so Morph fee-token state access is captured without crashing and muxed tracers receive system-call and nonce-v2 events
- make `traceCall` precredit alt-fee ERC20 balances, including dynamic slot discovery for tokens without configured balance slots, and add focused regression coverage

## Test plan
- [x] `go test ./core -run TestStartSystemCallTrace`
- [x] `go test ./eth/tracers -run 'TestTraceCall|TestTraceBlockByNumber|TestAddERC20BalanceDynamicSlotDiscovery'`
- [x] `go test ./eth/tracers/native -run 'TestFourByteTracerSkipsSystemCalls|TestMuxTracerForwardsSystemCallsAndNonceChangeV2|TestPrestateTracer'`
- [x] `go test ./eth/tracers/logger -run TestJSONLoggerSkipsSystemCallV2`
- [x] `go test ./eth/tracers/js -run TestJSTracerSkipsSystemCalls`
- [ ] Full `./eth/tracers/internal/tracetest` suite still has pre-existing fixture and VM failures on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced system-call tracing across tracers for clearer, isolated trace output.
  * Improved ERC20/ALT balance handling with dynamic slot discovery, synthetic precredit masking, and automatic balance updates.
  * Tracer output now includes an l1DataFee field in JSON results.

* **Bug Fixes**
  * Tracers reliably skip internal/system-call events from step/frame logs and JSON output.
  * More accurate prestate population and state-change recording.

* **Tests**
  * Added unit tests covering system-call handling, tracer suppression, synthetic precredit masking, and ERC20 balance discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->