### PR TITLE
fix: handle nil parameter in morph_diskRoot RPC to prevent panic

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -688,6 +688,10 @@ type DiskAndHeaderRoot struct {
 // This is useful for debugging cross-format state access (zkTrie ↔ MPT).
 // If no disk root mapping exists, returns the block's root for both fields.
 func (api *MorphAPI) DiskRoot(ctx context.Context, blockNrOrHash *rpc.BlockNumberOrHash) (DiskAndHeaderRoot, error) {
+	if blockNrOrHash == nil {
+		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		blockNrOrHash = &latest
+	}
 	block, err := api.eth.APIBackend.BlockByNumberOrHash(ctx, *blockNrOrHash)
 	if err != nil {
 		return DiskAndHeaderRoot{}, fmt.Errorf("failed to retrieve block: %w", err)


### PR DESCRIPTION
## Summary
- Calling `morph_diskRoot` without parameters causes a nil pointer dereference panic ("method handler crashed"), because `blockNrOrHash` is a pointer type that becomes `nil` when omitted
- Added nil check to default to `latest` block when no parameter is provided, consistent with standard eth RPC conventions

## Test plan
- [ ] Call `morph_diskRoot` without parameters — should return latest block's disk root instead of crashing
- [ ] Call `morph_diskRoot` with a block number parameter — should behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved API robustness by automatically defaulting to the latest block number when a specific block reference is not provided in requests, eliminating potential null pointer errors and ensuring requests complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->