### PR TITLE
feat: add NewL2BlockV2 with reorg support

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2022,8 +2022,14 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	for i := len(newChain) - 1; i >= 1; i-- {
 		rawdb.WriteReferenceIndexEntriesForBlock(indexesBatch, newChain[i])
 	}
-	// Delete any canonical number assignments above the new head
-	number := bc.CurrentBlock().NumberU64()
+	// Delete any canonical number assignments above the new head.
+	// When len(newChain) <= 1 (short-chain reorg), the insert loop above doesn't
+	// run, so bc.CurrentBlock() is still the old head. Use commonBlock as the base
+	// to correctly delete stale canonical hashes above the fork point.
+	number := commonBlock.NumberU64()
+	if len(newChain) > 1 {
+		number = newChain[1].NumberU64()
+	}
 	for i := number + 1; ; i++ {
 		hash := rawdb.ReadCanonicalHash(bc.db, i)
 		if hash == (common.Hash{}) {

--- a/core/blockchain_l2.go
+++ b/core/blockchain_l2.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -13,6 +14,18 @@ import (
 	"github.com/morph-l2/go-ethereum/ethdb"
 	"github.com/morph-l2/go-ethereum/log"
 )
+
+// ErrInvalidNextL1MsgIndex is returned when a block's header.NextL1MsgIndex
+// disagrees with the value derived from the canonical L1 message stream
+// (parent's FirstQueueIndexNotInL2Block + L1 messages processed in this block).
+//
+// header.NextL1MsgIndex is NOT covered by Header.Hash() (see core/types/block.go
+// headerHashing layout), so a signature-replay attacker can tamper with this
+// field independently from the block hash. The locally derived value, in
+// contrast, is computed from L1MessageTx queue indexes inside the block body
+// which DO participate in Header.TxHash and therefore the block hash, so any
+// mismatch indicates the on-wire header field was tampered with.
+var ErrInvalidNextL1MsgIndex = errors.New("invalid block.NextL1MsgIndex")
 
 func (bc *BlockChain) UpdateBlockProcessMetrics(statedb *state.StateDB, procTime time.Duration) {
 	// Update the metrics touched during block processing
@@ -93,6 +106,29 @@ func (bc *BlockChain) writeBlockStateWithoutHead(block *types.Block, receipts []
 	if queueIndex != nil {
 		numProcessed := uint64(block.NumL1MessagesProcessed(*queueIndex))
 		newIndex := *queueIndex + numProcessed
+
+		// Cross-check the header's NextL1MsgIndex against the value derived from
+		// the canonical L1 message stream. See ErrInvalidNextL1MsgIndex doc for
+		// the threat model: this field is not covered by Header.Hash(), so it
+		// must be validated against an independent source before persisting.
+		// Rejecting here ensures the block batch is never written and downstream
+		// state (chain head, executor.nextL1MsgIndex, prover RPC) cannot read a
+		// tampered value from disk.
+		if block.Header().NextL1MsgIndex != newIndex {
+			log.Error(
+				"NextL1MsgIndex mismatch, refusing to write block (tampering or sequencer bug)",
+				"number", block.NumberU64(),
+				"hash", block.Hash().Hex(),
+				"header", block.Header().NextL1MsgIndex,
+				"computed", newIndex,
+				"parentQueueIndex", *queueIndex,
+				"numProcessed", numProcessed,
+			)
+			return fmt.Errorf("%w at #%d %s: header=%d, computed=%d (parent q=%d, processed=%d)",
+				ErrInvalidNextL1MsgIndex, block.NumberU64(), block.Hash().Hex(),
+				block.Header().NextL1MsgIndex, newIndex, *queueIndex, numProcessed)
+		}
+
 		log.Trace(
 			"Blockchain.writeBlockStateWithoutHead WriteFirstQueueIndexNotInL2Block",
 			"number", block.Number(),

--- a/eth/catalyst/l2_api.go
+++ b/eth/catalyst/l2_api.go
@@ -483,6 +483,19 @@ func (api *l2ConsensusAPI) NewL2BlockV2(params ExecutableL2Data, isSafe bool) (e
 	if err != nil {
 		return err
 	}
+	// Defense against signature-replay: ensure the declared block hash matches the
+	// hash recomputed from the canonical fields. Without this check, an attacker
+	// could keep params.Hash from a legitimately signed block while tampering with
+	// other content fields, and have the signature verification on the consensus
+	// side accept the tampered body. This is the last line of defense before the
+	// block is committed to the chain; the tendermint side performs the same check
+	// earlier in VerifyBlockSignature to reject tampered blocks before propagation.
+	if (params.Hash != common.Hash{}) && block.Hash() != params.Hash {
+		log.Error("NewL2BlockV2 hash mismatch (signature replay or tampering)",
+			"declared", params.Hash.Hex(), "computed", block.Hash().Hex(), "number", params.Number)
+		return fmt.Errorf("block hash mismatch: declared %s, computed %s",
+			params.Hash.Hex(), block.Hash().Hex())
+	}
 
 	defer func() {
 		if err == nil {

--- a/eth/catalyst/l2_api.go
+++ b/eth/catalyst/l2_api.go
@@ -459,3 +459,53 @@ func (api *l2ConsensusAPI) AssembleL2BlockV2(parentHash common.Hash, timestamp *
 		Hash: newBlockResult.Block.Hash(),
 	}, nil
 }
+
+// NewL2BlockV2 commits a block with reorg support.
+// Unlike NewL2Block, it only requires the parent to exist (not be currentHead).
+// SetCanonical internally detects parentHash != currentHead and triggers reorg automatically.
+// isSafe=true skips verifyBlock and ValidateState (for L1-confirmed blocks).
+func (api *l2ConsensusAPI) NewL2BlockV2(params ExecutableL2Data, isSafe bool) (err error) {
+	api.newBlockLock.Lock()
+	defer api.newBlockLock.Unlock()
+
+	bc := api.eth.BlockChain()
+
+	parentHeader := bc.GetHeaderByHash(params.ParentHash)
+	if parentHeader == nil {
+		return fmt.Errorf("parent block not found: %s", params.ParentHash.Hex())
+	}
+	if params.Number != parentHeader.Number.Uint64()+1 {
+		return fmt.Errorf("wrong block number: expected %d, got %d",
+			parentHeader.Number.Uint64()+1, params.Number)
+	}
+
+	block, err := api.executableDataToBlock(params, nil)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err == nil {
+			api.verified = make(map[common.Hash]executionResult)
+		}
+	}()
+
+	if bas, verified := api.isVerified(block.Hash()); verified {
+		bc.UpdateBlockProcessMetrics(bas.state, bas.procTime)
+		return bc.WriteStateAndSetHead(block, bas.receipts, bas.state, bas.procTime)
+	}
+
+	if !isSafe {
+		if err = api.verifyBlock(block); err != nil {
+			log.Error("failed to verify block", "error", err)
+			return err
+		}
+	}
+
+	stateDB, receipts, _, procTime, err := bc.ProcessBlock(block, parentHeader, isSafe)
+	if err != nil {
+		return err
+	}
+
+	return bc.WriteStateAndSetHead(block, receipts, stateDB, procTime)
+}

--- a/eth/catalyst/l2_api_test.go
+++ b/eth/catalyst/l2_api_test.go
@@ -258,6 +258,180 @@ func makeL1Txs(fromIndex, count int) (types.Transactions, []types.L1MessageTx) {
 	return l1Txs, l1Messages
 }
 
+func TestNewL2BlockV2(t *testing.T) {
+	// Build a chain of 10 blocks for reorg testing
+	num := 10
+	genesis, blocks := generateTestL2Chain(num)
+	n, ethService := startEthService(t, genesis, blocks)
+	defer n.Close()
+
+	// Write FirstQueueIndexNotInL2Block for all blocks (required by writeBlockStateWithoutHead)
+	genesisBlock := ethService.BlockChain().GetBlockByNumber(0)
+	rawdb.WriteFirstQueueIndexNotInL2Block(ethService.ChainDb(), genesisBlock.Hash(), 0)
+	for _, block := range blocks {
+		rawdb.WriteFirstQueueIndexNotInL2Block(ethService.ChainDb(), block.Hash(), 0)
+	}
+
+	api := newL2ConsensusAPI(ethService)
+	config := l2ChainConfig()
+	bc := ethService.BlockChain()
+
+	// TC-01: Normal sequential block (parent == currentHead)
+	t.Run("NormalSequentialBlock", func(t *testing.T) {
+		err := sendTransfer(config, ethService)
+		require.NoError(t, err)
+
+		currentHash := bc.CurrentBlock().Hash()
+		ret, err := ethService.Miner().BuildBlock(currentHash, time.Now(), nil)
+		require.NoError(t, err)
+
+		data := ExecutableL2Data{
+			ParentHash:   ret.Block.ParentHash(),
+			Number:       ret.Block.NumberU64(),
+			Miner:        ret.Block.Coinbase(),
+			Timestamp:    ret.Block.Time(),
+			GasLimit:     ret.Block.GasLimit(),
+			BaseFee:      ret.Block.BaseFee(),
+			Transactions: encodeTransactions(ret.Block.Transactions()),
+			StateRoot:    ret.Block.Root(),
+			GasUsed:      ret.Block.GasUsed(),
+			ReceiptRoot:  ret.Block.ReceiptHash(),
+			LogsBloom:    ret.Block.Bloom().Bytes(),
+		}
+
+		err = api.NewL2BlockV2(data, false)
+		require.NoError(t, err)
+		require.EqualValues(t, num+1, bc.CurrentBlock().NumberU64())
+	})
+
+	// TC-03: Parent not found
+	t.Run("ParentNotFound", func(t *testing.T) {
+		data := ExecutableL2Data{
+			ParentHash: common.HexToHash("0xdeadbeef"),
+			Number:     999,
+		}
+		err := api.NewL2BlockV2(data, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parent block not found")
+	})
+
+	// TC-04: Wrong block number (not parent+1)
+	t.Run("WrongBlockNumber", func(t *testing.T) {
+		data := ExecutableL2Data{
+			ParentHash: bc.CurrentBlock().Hash(),
+			Number:     999, // wrong
+		}
+		err := api.NewL2BlockV2(data, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wrong block number")
+	})
+
+	// TC-02 + TC-06: Reorg from height 11 to build on block 7
+	t.Run("Reorg", func(t *testing.T) {
+		currentHead := bc.CurrentBlock().NumberU64() // should be 11 after TC-01
+		require.True(t, currentHead >= 10, "chain must be at least 10 blocks")
+
+		// Get block 7 as reorg parent
+		block7 := bc.GetBlockByNumber(7)
+		require.NotNil(t, block7)
+
+		// Build a new block on top of block 7
+		ret, err := ethService.Miner().BuildBlock(block7.Hash(), time.Now(), nil)
+		require.NoError(t, err)
+		newBlock := ret.Block
+
+		data := ExecutableL2Data{
+			ParentHash:   newBlock.ParentHash(),
+			Number:       newBlock.NumberU64(),
+			Miner:        newBlock.Coinbase(),
+			Timestamp:    newBlock.Time(),
+			GasLimit:     newBlock.GasLimit(),
+			BaseFee:      newBlock.BaseFee(),
+			Transactions: encodeTransactions(newBlock.Transactions()),
+			StateRoot:    newBlock.Root(),
+			GasUsed:      newBlock.GasUsed(),
+			ReceiptRoot:  newBlock.ReceiptHash(),
+			LogsBloom:    newBlock.Bloom().Bytes(),
+		}
+
+		// Apply the reorg block via NewL2BlockV2
+		err = api.NewL2BlockV2(data, false)
+		require.NoError(t, err)
+
+		// Verify chain head is now at height 8
+		require.EqualValues(t, 8, bc.CurrentBlock().NumberU64())
+
+		// TC-06: Verify stale canonical hashes are cleaned
+		for h := uint64(9); h <= currentHead; h++ {
+			hash := rawdb.ReadCanonicalHash(ethService.ChainDb(), h)
+			require.Equal(t, common.Hash{}, hash, "canonical hash at height %d should be empty after reorg", h)
+		}
+
+		// Verify new block is canonical at height 8
+		canonicalHash8 := rawdb.ReadCanonicalHash(ethService.ChainDb(), 8)
+		require.NotEqual(t, common.Hash{}, canonicalHash8)
+	})
+
+	// TC-07: Consecutive reorg - now at height 8, reorg to build on block 5
+	t.Run("ConsecutiveReorg", func(t *testing.T) {
+		block5 := bc.GetBlockByNumber(5)
+		require.NotNil(t, block5)
+
+		ret, err := ethService.Miner().BuildBlock(block5.Hash(), time.Now(), nil)
+		require.NoError(t, err)
+		newBlock := ret.Block
+
+		data := ExecutableL2Data{
+			ParentHash:   newBlock.ParentHash(),
+			Number:       newBlock.NumberU64(),
+			Miner:        newBlock.Coinbase(),
+			Timestamp:    newBlock.Time(),
+			GasLimit:     newBlock.GasLimit(),
+			BaseFee:      newBlock.BaseFee(),
+			Transactions: encodeTransactions(newBlock.Transactions()),
+			StateRoot:    newBlock.Root(),
+			GasUsed:      newBlock.GasUsed(),
+			ReceiptRoot:  newBlock.ReceiptHash(),
+			LogsBloom:    newBlock.Bloom().Bytes(),
+		}
+
+		err = api.NewL2BlockV2(data, false)
+		require.NoError(t, err)
+		require.EqualValues(t, 6, bc.CurrentBlock().NumberU64())
+
+		// Stale canonical hashes at 7, 8 should be empty
+		for h := uint64(7); h <= 8; h++ {
+			hash := rawdb.ReadCanonicalHash(ethService.ChainDb(), h)
+			require.Equal(t, common.Hash{}, hash, "height %d should be empty", h)
+		}
+	})
+
+	// TC-05: isSafe=true path
+	t.Run("SafeBlock", func(t *testing.T) {
+		currentHash := bc.CurrentBlock().Hash()
+		ret, err := ethService.Miner().BuildBlock(currentHash, time.Now(), nil)
+		require.NoError(t, err)
+		newBlock := ret.Block
+
+		data := ExecutableL2Data{
+			ParentHash:   newBlock.ParentHash(),
+			Number:       newBlock.NumberU64(),
+			Miner:        newBlock.Coinbase(),
+			Timestamp:    newBlock.Time(),
+			GasLimit:     newBlock.GasLimit(),
+			BaseFee:      newBlock.BaseFee(),
+			Transactions: encodeTransactions(newBlock.Transactions()),
+			StateRoot:    newBlock.Root(),
+			GasUsed:      newBlock.GasUsed(),
+			ReceiptRoot:  newBlock.ReceiptHash(),
+			LogsBloom:    newBlock.Bloom().Bytes(),
+		}
+
+		err = api.NewL2BlockV2(data, true)
+		require.NoError(t, err)
+	})
+}
+
 func sendTransfer(config params.ChainConfig, ethService *eth.Ethereum) error {
 	tx, err := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*2), nil), types.LatestSigner(&config), testKey)
 	if err != nil {

--- a/eth/catalyst/l2_api_test.go
+++ b/eth/catalyst/l2_api_test.go
@@ -1,6 +1,7 @@
 package catalyst
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -370,6 +371,80 @@ func TestNewL2BlockV2(t *testing.T) {
 		// Verify new block is canonical at height 8
 		canonicalHash8 := rawdb.ReadCanonicalHash(ethService.ChainDb(), 8)
 		require.NotEqual(t, common.Hash{}, canonicalHash8)
+	})
+
+	// TC-07: header.NextL1MsgIndex must match the value derived from the
+	// canonical L1 message stream. This field is not covered by Header.Hash(),
+	// so a signature-replay attacker could otherwise set it freely. The check
+	// in writeBlockStateWithoutHead must reject the block before it is
+	// persisted, leaving the chain head untouched.
+	t.Run("TamperedNextL1MessageIndex", func(t *testing.T) {
+		headBefore := bc.CurrentBlock().Hash()
+		numberBefore := bc.CurrentBlock().NumberU64()
+
+		ret, err := ethService.Miner().BuildBlock(headBefore, time.Now(), nil)
+		require.NoError(t, err)
+
+		// The honest miner produces a block with NextL1MsgIndex == 0 here
+		// (no L1 messages in the test setup). Tampering it to a non-zero
+		// value mimics an attacker who replays a legitimate signature while
+		// flipping bits in fields not bound to the block hash.
+		require.EqualValues(t, 0, ret.Block.Header().NextL1MsgIndex,
+			"sanity: honest block should have NextL1MsgIndex = 0 in this test setup")
+
+		data := ExecutableL2Data{
+			ParentHash:         ret.Block.ParentHash(),
+			Number:             ret.Block.NumberU64(),
+			Miner:              ret.Block.Coinbase(),
+			Timestamp:          ret.Block.Time(),
+			GasLimit:           ret.Block.GasLimit(),
+			BaseFee:            ret.Block.BaseFee(),
+			Transactions:       encodeTransactions(ret.Block.Transactions()),
+			StateRoot:          ret.Block.Root(),
+			GasUsed:            ret.Block.GasUsed(),
+			ReceiptRoot:        ret.Block.ReceiptHash(),
+			LogsBloom:          ret.Block.Bloom().Bytes(),
+			NextL1MessageIndex: 99, // tampered
+		}
+
+		err = api.NewL2BlockV2(data, false)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, core.ErrInvalidNextL1MsgIndex),
+			"expected ErrInvalidNextL1MsgIndex, got: %v", err)
+
+		// Chain head must not have advanced.
+		require.Equal(t, headBefore, bc.CurrentBlock().Hash(),
+			"head must not move when block is rejected")
+		require.Equal(t, numberBefore, bc.CurrentBlock().NumberU64())
+	})
+
+	// TC-08: Honest NextL1MsgIndex on the same parent should still apply
+	// cleanly, proving the check does not over-reject after TC-07.
+	t.Run("HonestNextL1MessageIndexAfterTampered", func(t *testing.T) {
+		headBefore := bc.CurrentBlock().Hash()
+		numberBefore := bc.CurrentBlock().NumberU64()
+
+		ret, err := ethService.Miner().BuildBlock(headBefore, time.Now(), nil)
+		require.NoError(t, err)
+
+		data := ExecutableL2Data{
+			ParentHash:         ret.Block.ParentHash(),
+			Number:             ret.Block.NumberU64(),
+			Miner:              ret.Block.Coinbase(),
+			Timestamp:          ret.Block.Time(),
+			GasLimit:           ret.Block.GasLimit(),
+			BaseFee:            ret.Block.BaseFee(),
+			Transactions:       encodeTransactions(ret.Block.Transactions()),
+			StateRoot:          ret.Block.Root(),
+			GasUsed:            ret.Block.GasUsed(),
+			ReceiptRoot:        ret.Block.ReceiptHash(),
+			LogsBloom:          ret.Block.Bloom().Bytes(),
+			NextL1MessageIndex: ret.Block.Header().NextL1MsgIndex, // honest
+		}
+
+		err = api.NewL2BlockV2(data, false)
+		require.NoError(t, err)
+		require.Equal(t, numberBefore+1, bc.CurrentBlock().NumberU64())
 	})
 
 	// TC-07: Consecutive reorg - now at height 8, reorg to build on block 5

--- a/ethclient/authclient/engine.go
+++ b/ethclient/authclient/engine.go
@@ -42,6 +42,13 @@ func (ec *Client) NewL2Block(ctx context.Context, executableL2Data *catalyst.Exe
 	return ec.c.CallContext(ctx, nil, "engine_newL2Block", executableL2Data, batchHash)
 }
 
+// NewL2BlockV2 executes L2 Block with reorg support, and sets the block to chain.
+// Unlike NewL2Block, parent is not required to be the current head — reorg is handled
+// automatically by SetCanonical. isSafe=true skips header and state validation.
+func (ec *Client) NewL2BlockV2(ctx context.Context, executableL2Data *catalyst.ExecutableL2Data, isSafe bool) error {
+	return ec.c.CallContext(ctx, nil, "engine_newL2BlockV2", executableL2Data, isSafe)
+}
+
 // NewSafeL2Block executes a safe L2 Block, and set the block to chain
 func (ec *Client) NewSafeL2Block(ctx context.Context, safeL2Data *catalyst.SafeL2Data) (*types.Header, error) {
 	var header types.Header


### PR DESCRIPTION
## Summary

- Add `engine_newL2BlockV2` API that relaxes parent constraint from "must be currentHead" to "must exist", enabling `SetCanonical` to automatically handle chain reorganization
- Fix `reorg()` canonical hash deletion loop start point (`commonBlock.Number`) to correctly clean up stale canonical hashes after short-chain reorgs where `len(newChain) <= 1`
- Add `authclient.Client.NewL2BlockV2` RPC wrapper

## Key design decisions

- `NewL2Block` is unchanged (backward compatible); `NewL2BlockV2` is a new independent method
- No `batchHash` parameter: reorg path always passes nil; batch boundary is a consensus delivery concern
- `isSafe bool`: when `true`, skips `verifyBlock` and `ValidateState` for L1-confirmed blocks from derivation
- geth does not detect or reason about reorg; it only validates parent exists + number == parent+1 and lets `SetCanonical` handle reorg automatically

## Test plan

- [x] `go test ./eth/catalyst/ -run TestNewL2BlockV2 -v` — 6 subtests: sequential, reorg, parent-not-found, wrong-number, isSafe path, consecutive reorg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed canonical-hash cleanup during short-chain reorganizations and added stricter validation to reject blocks with incorrect NextL1MessageIndex.

* **New Features**
  * Added an L2 block submission API with optional "safe" mode to skip verification and a corresponding client call for remote invocation.

* **Tests**
  * Added comprehensive tests covering sequential application, reorg scenarios, validation failures, and safe-path execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->