### PR TITLE
build: route migration tools to build/bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ build/_vendor/pkg
 /build/_workspace/
 /build/cache/
 /build/bin/
-/migration-checker
 /geth*.zip
 
 # travis

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build/_vendor/pkg
 /build/_workspace/
 /build/cache/
 /build/bin/
+/migration-checker
 /geth*.zip
 
 # travis

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # with Go source code. If you know what GOPATH is then you probably
 # don't need to bother with make. 
 
-.PHONY: geth android ios evm all test clean libzkp
+.PHONY: geth migration-checker gen-preimages android ios evm all test clean libzkp
 
 GOBIN = ./build/bin
 GO ?= latest
@@ -12,6 +12,16 @@ geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
+
+migration-checker:
+	$(GORUN) build/ci.go install ./cmd/migration-checker
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/migration-checker\" to launch migration-checker."
+
+gen-preimages:
+	$(GORUN) build/ci.go install ./cmd/gen-preimages
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/gen-preimages\" to launch gen-preimages."
 
 all:
 	$(GORUN) build/ci.go install


### PR DESCRIPTION
## Summary
- add `Makefile` targets for `migration-checker` and `gen-preimages` using `build/ci.go install ./cmd/...`
- ensure these tool binaries are emitted under `build/bin` like other binaries
- ignore root-level `migration-checker` to avoid accidental binary commits from default `go build` output

## Test plan
- [x] verify `git diff origin/main...HEAD` only includes `Makefile` and `.gitignore`
- [ ] run `make migration-checker` and confirm output is `build/bin/migration-checker`
- [ ] run `make gen-preimages` and confirm output is `build/bin/gen-preimages`

Made with [Cursor](https://cursor.com)