### PR TITLE
feat: optimize DeriveSha list hashing

### DIFF
--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -46,9 +46,10 @@ func (h *testHasher) Reset() {
 	h.hasher.Reset()
 }
 
-func (h *testHasher) Update(key, val []byte) {
+func (h *testHasher) Update(key, val []byte) error {
 	h.hasher.Write(key)
 	h.hasher.Write(val)
+	return nil
 }
 
 func (h *testHasher) Hash() common.Hash {

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -363,7 +363,9 @@ func generateTrieRoot(db ethdb.KeyValueWriter, it Iterator, account common.Hash,
 func stackTrieGenerate(db ethdb.KeyValueWriter, in chan trieKV, out chan common.Hash) {
 	t := trie.NewStackTrie(db)
 	for leaf := range in {
-		t.TryUpdate(leaf.key[:], leaf.value)
+		if err := t.TryUpdate(leaf.key[:], leaf.value); err != nil {
+			panic(err) // Really shouldn't ever happen
+		}
 	}
 	var root common.Hash
 	if db == nil {

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -310,7 +310,9 @@ func (dl *diskLayer) proveRange(stats *generatorStats, root common.Hash, prefix 
 	if origin == nil && !diskMore {
 		stackTr := trie.NewStackTrie(nil)
 		for i, key := range keys {
-			stackTr.TryUpdate(key, vals[i])
+			if err := stackTr.TryUpdate(key, vals[i]); err != nil {
+				return nil, err
+			}
 		}
 		if gotRoot := stackTr.Hash(); gotRoot != root {
 			return &proofResult{

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -267,7 +267,7 @@ type extblock struct {
 // The values of TxHash, UncleHash, ReceiptHash and Bloom in header
 // are ignored and set to values derived from the given txs, uncles
 // and receipts.
-func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*Receipt, hasher TrieHasher) *Block {
+func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*Receipt, hasher ListHasher) *Block {
 	b := &Block{header: CopyHeader(header), td: new(big.Int)}
 
 	// TODO: panic if len(txs) != len(receipts)

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -233,9 +233,10 @@ func (h *testHasher) Reset() {
 	h.hasher.Reset()
 }
 
-func (h *testHasher) Update(key, val []byte) {
+func (h *testHasher) Update(key, val []byte) error {
 	h.hasher.Write(key)
 	h.hasher.Write(val)
+	return nil
 }
 
 func (h *testHasher) Hash() common.Hash {

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -77,11 +77,11 @@ func prefixedRlpHash(prefix byte, x interface{}) (h common.Hash) {
 	return h
 }
 
-// TrieHasher is the tool used to calculate the hash of derivable list.
+// ListHasher is the tool used to calculate the hash of derivable list.
 // This is internal, do not use.
-type TrieHasher interface {
+type ListHasher interface {
 	Reset()
-	Update([]byte, []byte)
+	Update(key []byte, value []byte) error
 	Hash() common.Hash
 }
 
@@ -96,19 +96,17 @@ type DerivableList interface {
 func encodeForDerive(list DerivableList, i int, buf *bytes.Buffer) []byte {
 	buf.Reset()
 	list.EncodeIndex(i, buf)
-	// It's really unfortunate that we need to do perform this copy.
-	// StackTrie holds onto the values until Hash is called, so the values
-	// written to it must not alias.
-	return common.CopyBytes(buf.Bytes())
+	return buf.Bytes()
 }
 
 // DeriveSha creates the tree hashes of transactions and receipts in a block header.
-func DeriveSha(list DerivableList, hasher TrieHasher) common.Hash {
+func DeriveSha(list DerivableList, hasher ListHasher) common.Hash {
 	hasher.Reset()
 
 	valueBuf := encodeBufferPool.Get().(*bytes.Buffer)
 	defer encodeBufferPool.Put(valueBuf)
 
+	// Hashers copy key-value pairs on Update, so the encoder buffer can be reused.
 	// StackTrie requires values to be inserted in increasing hash order, which is not the
 	// order that `list` provides hashes in. This insertion sequence ensures that the
 	// order is correct.

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -110,21 +110,31 @@ func DeriveSha(list DerivableList, hasher ListHasher) common.Hash {
 	// StackTrie requires values to be inserted in increasing hash order, which is not the
 	// order that `list` provides hashes in. This insertion sequence ensures that the
 	// order is correct.
+	//
+	// Update only fails for a zero-length value, which is impossible here because every
+	// RLP-encoded list item is at least one byte. Panic on error to keep the fail-loud
+	// semantics of consensus root calculation rather than silently dropping a leaf.
 	var indexBuf []byte
 	for i := 1; i < list.Len() && i <= 0x7f; i++ {
 		indexBuf = rlp.AppendUint64(indexBuf[:0], uint64(i))
 		value := encodeForDerive(list, i, valueBuf)
-		hasher.Update(indexBuf, value)
+		if err := hasher.Update(indexBuf, value); err != nil {
+			panic(err)
+		}
 	}
 	if list.Len() > 0 {
 		indexBuf = rlp.AppendUint64(indexBuf[:0], 0)
 		value := encodeForDerive(list, 0, valueBuf)
-		hasher.Update(indexBuf, value)
+		if err := hasher.Update(indexBuf, value); err != nil {
+			panic(err)
+		}
 	}
 	for i := 0x80; i < list.Len(); i++ {
 		indexBuf = rlp.AppendUint64(indexBuf[:0], uint64(i))
 		value := encodeForDerive(list, i, valueBuf)
-		hasher.Update(indexBuf, value)
+		if err := hasher.Update(indexBuf, value); err != nil {
+			panic(err)
+		}
 	}
 	return hasher.Hash()
 }

--- a/core/types/hashing_test.go
+++ b/core/types/hashing_test.go
@@ -24,6 +24,7 @@ import (
 	mrand "math/rand"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/morph-l2/go-ethereum/common"
 	"github.com/morph-l2/go-ethereum/common/hexutil"
 	"github.com/morph-l2/go-ethereum/core/types"
@@ -38,7 +39,7 @@ func TestDeriveSha(t *testing.T) {
 		t.Fatal(err)
 	}
 	for len(txs) < 1000 {
-		exp := types.DeriveSha(txs, new(trie.Trie))
+		exp := types.DeriveSha(txs, trie.NewListHasher())
 		got := types.DeriveSha(txs, trie.NewStackTrie(nil))
 		if !bytes.Equal(got[:], exp[:]) {
 			t.Fatalf("%d txs: got %x exp %x", len(txs), got, exp)
@@ -49,6 +50,45 @@ func TestDeriveSha(t *testing.T) {
 		}
 		txs = append(txs, newTxs...)
 	}
+}
+
+func TestDeriveShaStackTrieMatchesListHasher(t *testing.T) {
+	txs, err := genTxs(16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDeriveShaMatches(t, txs)
+	assertDeriveShaMatches(t, typedDeriveShaTransactions())
+	assertDeriveShaMatches(t, typedDeriveShaReceipts())
+}
+
+func TestDeriveShaBufferReuseDoesNotAlias(t *testing.T) {
+	list := flatList{
+		"0x010203040506070809",
+		"0x101112131415161718191a1b1c1d1e1f",
+		"0x202122232425262728292a2b2c2d2e2f30313233",
+	}
+	assertDeriveShaMatches(t, list)
+}
+
+func TestBlobTxDeriveSha(t *testing.T) {
+	assertDeriveShaMatches(t, types.Transactions{typedDeriveShaTransactions()[2]})
+	assertDeriveShaMatches(t, types.Receipts{typedReceipt(types.BlobTxType)})
+}
+
+func TestSetCodeTxDeriveSha(t *testing.T) {
+	assertDeriveShaMatches(t, types.Transactions{typedDeriveShaTransactions()[3]})
+	assertDeriveShaMatches(t, types.Receipts{typedReceipt(types.SetCodeTxType)})
+}
+
+func TestMorphTxDeriveSha(t *testing.T) {
+	assertDeriveShaMatches(t, types.Transactions{typedDeriveShaTransactions()[5]})
+	assertDeriveShaMatches(t, types.Receipts{typedReceipt(types.MorphTxType)})
+}
+
+func TestL1MessageReceiptDeriveSha(t *testing.T) {
+	assertDeriveShaMatches(t, types.Transactions{typedDeriveShaTransactions()[4]})
+	assertDeriveShaMatches(t, types.Receipts{typedReceipt(types.L1MessageTxType)})
 }
 
 // TestEIP2718DeriveSha tests that the input to the DeriveSha function is correct.
@@ -85,7 +125,7 @@ func BenchmarkDeriveSha200(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			exp = types.DeriveSha(txs, new(trie.Trie))
+			exp = types.DeriveSha(txs, trie.NewListHasher())
 		}
 	})
 
@@ -106,7 +146,7 @@ func TestFuzzDeriveSha(t *testing.T) {
 	rndSeed := mrand.Int()
 	for i := 0; i < 10; i++ {
 		seed := rndSeed + i
-		exp := types.DeriveSha(newDummy(i), new(trie.Trie))
+		exp := types.DeriveSha(newDummy(i), trie.NewListHasher())
 		got := types.DeriveSha(newDummy(i), trie.NewStackTrie(nil))
 		if !bytes.Equal(got[:], exp[:]) {
 			printList(newDummy(seed))
@@ -134,7 +174,7 @@ func TestDerivableList(t *testing.T) {
 		},
 	}
 	for i, tc := range tcs[1:] {
-		exp := types.DeriveSha(flatList(tc), new(trie.Trie))
+		exp := types.DeriveSha(flatList(tc), trie.NewListHasher())
 		got := types.DeriveSha(flatList(tc), trie.NewStackTrie(nil))
 		if !bytes.Equal(got[:], exp[:]) {
 			t.Fatalf("case %d: got %x exp %x", i, got, exp)
@@ -163,6 +203,122 @@ func genTxs(num uint64) (types.Transactions, error) {
 		txs = append(txs, tx)
 	}
 	return txs, nil
+}
+
+func assertDeriveShaMatches(t *testing.T, list types.DerivableList) {
+	t.Helper()
+	exp := types.DeriveSha(list, trie.NewListHasher())
+	got := types.DeriveSha(list, trie.NewStackTrie(nil))
+	if got != exp {
+		t.Fatalf("%T root mismatch: got %x exp %x", list, got, exp)
+	}
+}
+
+func typedDeriveShaTransactions() types.Transactions {
+	to := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	return types.Transactions{
+		types.NewTx(&types.AccessListTx{
+			ChainID:  big.NewInt(1),
+			Nonce:    1,
+			GasPrice: big.NewInt(1),
+			Gas:      21000,
+			To:       &to,
+			Value:    big.NewInt(1),
+			Data:     []byte{0x01},
+			V:        big.NewInt(0),
+			R:        big.NewInt(1),
+			S:        big.NewInt(1),
+		}),
+		types.NewTx(&types.DynamicFeeTx{
+			ChainID:   big.NewInt(1),
+			Nonce:     2,
+			GasTipCap: big.NewInt(1),
+			GasFeeCap: big.NewInt(2),
+			Gas:       21000,
+			To:        &to,
+			Value:     big.NewInt(2),
+			Data:      []byte{0x02},
+			V:         big.NewInt(0),
+			R:         big.NewInt(1),
+			S:         big.NewInt(1),
+		}),
+		types.NewTx(&types.BlobTx{
+			ChainID:    uint256.NewInt(1),
+			Nonce:      3,
+			GasTipCap:  uint256.NewInt(1),
+			GasFeeCap:  uint256.NewInt(2),
+			Gas:        21000,
+			To:         to,
+			Value:      uint256.NewInt(3),
+			Data:       []byte{0x03},
+			BlobFeeCap: uint256.NewInt(1),
+			BlobHashes: []common.Hash{common.HexToHash("0x01")},
+			V:          uint256.NewInt(0),
+			R:          uint256.NewInt(1),
+			S:          uint256.NewInt(1),
+		}),
+		types.NewTx(&types.SetCodeTx{
+			ChainID:   uint256.NewInt(1),
+			Nonce:     4,
+			GasTipCap: uint256.NewInt(1),
+			GasFeeCap: uint256.NewInt(2),
+			Gas:       21000,
+			To:        to,
+			Value:     uint256.NewInt(4),
+			Data:      []byte{0x04},
+			V:         uint256.NewInt(0),
+			R:         uint256.NewInt(1),
+			S:         uint256.NewInt(1),
+		}),
+		types.NewTx(&types.L1MessageTx{
+			QueueIndex: 5,
+			Gas:        21000,
+			To:         &to,
+			Value:      big.NewInt(5),
+			Data:       []byte{0x05},
+			Sender:     common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		}),
+		types.NewTx(&types.MorphTx{
+			ChainID:   big.NewInt(1),
+			Nonce:     6,
+			GasTipCap: big.NewInt(1),
+			GasFeeCap: big.NewInt(2),
+			Gas:       21000,
+			To:        &to,
+			Value:     big.NewInt(6),
+			Data:      []byte{0x06},
+			FeeLimit:  big.NewInt(1000),
+			V:         big.NewInt(0),
+			R:         big.NewInt(1),
+			S:         big.NewInt(1),
+		}),
+	}
+}
+
+func typedDeriveShaReceipts() types.Receipts {
+	return types.Receipts{
+		typedReceipt(types.AccessListTxType),
+		typedReceipt(types.DynamicFeeTxType),
+		typedReceipt(types.BlobTxType),
+		typedReceipt(types.SetCodeTxType),
+		typedReceipt(types.L1MessageTxType),
+		typedReceipt(types.MorphTxType),
+	}
+}
+
+func typedReceipt(txType uint8) *types.Receipt {
+	return &types.Receipt{
+		Type:              txType,
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: uint64(100 + txType),
+		Logs: []*types.Log{
+			{
+				Address: common.BytesToAddress([]byte{txType}),
+				Topics:  []common.Hash{common.BigToHash(big.NewInt(int64(txType)))},
+				Data:    []byte{txType, 0x01, 0x02},
+			},
+		},
+	}
 }
 
 type dummyDerivableList struct {
@@ -218,9 +374,10 @@ func (d *hashToHumanReadable) Reset() {
 	d.data = make([]byte, 0)
 }
 
-func (d *hashToHumanReadable) Update(i []byte, i2 []byte) {
+func (d *hashToHumanReadable) Update(i []byte, i2 []byte) error {
 	l := fmt.Sprintf("%x %x\n", i, i2)
 	d.data = append(d.data, []byte(l)...)
+	return nil
 }
 
 func (d *hashToHumanReadable) Hash() common.Hash {

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2042,7 +2042,9 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 		if i < len(res.hashes)-1 || res.subTask == nil {
 			tr := trie.NewStackTrie(batch)
 			for j := 0; j < len(res.hashes[i]); j++ {
-				tr.Update(res.hashes[i][j][:], res.slots[i][j])
+				if err := tr.Update(res.hashes[i][j][:], res.slots[i][j]); err != nil {
+					panic(err) // Really shouldn't ever happen
+				}
 			}
 			tr.Commit()
 		}
@@ -2055,7 +2057,9 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 			// If we're storing large contracts, generate the trie nodes
 			// on the fly to not trash the gluing points
 			if i == len(res.hashes)-1 && res.subTask != nil {
-				res.subTask.genTrie.Update(res.hashes[i][j][:], res.slots[i][j])
+				if err := res.subTask.genTrie.Update(res.hashes[i][j][:], res.slots[i][j]); err != nil {
+					panic(err) // Really shouldn't ever happen
+				}
 			}
 		}
 	}
@@ -2206,7 +2210,9 @@ func (s *Syncer) forwardAccountTask(task *accountTask) {
 			if err != nil {
 				panic(err) // Really shouldn't ever happen
 			}
-			task.genTrie.Update(hash[:], full)
+			if err := task.genTrie.Update(hash[:], full); err != nil {
+				panic(err) // Really shouldn't ever happen
+			}
 		}
 	}
 	// Flush anything written just now and update the stats

--- a/trie/bytepool.go
+++ b/trie/bytepool.go
@@ -1,0 +1,101 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+// bytesPool is a pool for byte slices. It is safe for concurrent use.
+type bytesPool struct {
+	c chan []byte
+	w int
+}
+
+// newBytesPool creates a new bytesPool. The sliceCap sets the capacity of
+// newly allocated slices, and the nitems determines how many items the pool
+// will hold, at maximum.
+func newBytesPool(sliceCap, nitems int) *bytesPool {
+	return &bytesPool{
+		c: make(chan []byte, nitems),
+		w: sliceCap,
+	}
+}
+
+// get returns a slice. Safe for concurrent use.
+func (bp *bytesPool) get() []byte {
+	select {
+	case b := <-bp.c:
+		return b
+	default:
+		return make([]byte, 0, bp.w)
+	}
+}
+
+// getWithSize returns a slice with specified byte slice size.
+func (bp *bytesPool) getWithSize(s int) []byte {
+	b := bp.get()
+	if cap(b) < s {
+		return make([]byte, s)
+	}
+	return b[:s]
+}
+
+// put returns a slice to the pool. Safe for concurrent use. This method will
+// ignore slices that are too small or too large (>3x the cap).
+func (bp *bytesPool) put(b []byte) {
+	if c := cap(b); c < bp.w || c > 3*bp.w {
+		return
+	}
+	select {
+	case bp.c <- b:
+	default:
+	}
+}
+
+// unsafeBytesPool is a pool for byte slices. It is not safe for concurrent use.
+type unsafeBytesPool struct {
+	items [][]byte
+	w     int
+}
+
+// newUnsafeBytesPool creates a new unsafeBytesPool. The sliceCap sets the
+// capacity of newly allocated slices, and the nitems determines how many items
+// the pool will hold, at maximum.
+func newUnsafeBytesPool(sliceCap, nitems int) *unsafeBytesPool {
+	return &unsafeBytesPool{
+		items: make([][]byte, 0, nitems),
+		w:     sliceCap,
+	}
+}
+
+// get returns a slice with pre-allocated space.
+func (bp *unsafeBytesPool) get() []byte {
+	if len(bp.items) > 0 {
+		last := bp.items[len(bp.items)-1]
+		bp.items = bp.items[:len(bp.items)-1]
+		return last
+	}
+	return make([]byte, 0, bp.w)
+}
+
+// put returns a slice to the pool. This method will ignore slices that are too
+// small or too large (>3x the cap).
+func (bp *unsafeBytesPool) put(b []byte) {
+	if c := cap(b); c < bp.w || c > 3*bp.w {
+		return
+	}
+	if len(bp.items) < cap(bp.items) {
+		bp.items = append(bp.items, b)
+	}
+}

--- a/trie/bytepool.go
+++ b/trie/bytepool.go
@@ -16,53 +16,6 @@
 
 package trie
 
-// bytesPool is a pool for byte slices. It is safe for concurrent use.
-type bytesPool struct {
-	c chan []byte
-	w int
-}
-
-// newBytesPool creates a new bytesPool. The sliceCap sets the capacity of
-// newly allocated slices, and the nitems determines how many items the pool
-// will hold, at maximum.
-func newBytesPool(sliceCap, nitems int) *bytesPool {
-	return &bytesPool{
-		c: make(chan []byte, nitems),
-		w: sliceCap,
-	}
-}
-
-// get returns a slice. Safe for concurrent use.
-func (bp *bytesPool) get() []byte {
-	select {
-	case b := <-bp.c:
-		return b
-	default:
-		return make([]byte, 0, bp.w)
-	}
-}
-
-// getWithSize returns a slice with specified byte slice size.
-func (bp *bytesPool) getWithSize(s int) []byte {
-	b := bp.get()
-	if cap(b) < s {
-		return make([]byte, s)
-	}
-	return b[:s]
-}
-
-// put returns a slice to the pool. Safe for concurrent use. This method will
-// ignore slices that are too small or too large (>3x the cap).
-func (bp *bytesPool) put(b []byte) {
-	if c := cap(b); c < bp.w || c > 3*bp.w {
-		return
-	}
-	select {
-	case bp.c <- b:
-	default:
-	}
-}
-
 // unsafeBytesPool is a pool for byte slices. It is not safe for concurrent use.
 type unsafeBytesPool struct {
 	items [][]byte

--- a/trie/list_hasher.go
+++ b/trie/list_hasher.go
@@ -1,0 +1,58 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"bytes"
+
+	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/core/types"
+	"github.com/morph-l2/go-ethereum/ethdb/memorydb"
+)
+
+var (
+	_ types.ListHasher = (*ListHasher)(nil)
+	_ types.ListHasher = (*StackTrie)(nil)
+)
+
+// ListHasher wraps a regular Merkle Patricia Trie for derivable list hashing.
+// It exists as a correctness oracle; StackTrie is the optimized production path.
+type ListHasher struct {
+	tr *Trie
+}
+
+// NewListHasher initializes a list hasher.
+func NewListHasher() *ListHasher {
+	tr, _ := New(common.Hash{}, NewDatabase(memorydb.New()))
+	return &ListHasher{tr: tr}
+}
+
+// Reset clears the internal trie state.
+func (h *ListHasher) Reset() {
+	h.tr.Reset()
+}
+
+// Update inserts a key-value pair into the trie.
+func (h *ListHasher) Update(key []byte, value []byte) error {
+	key, value = bytes.Clone(key), bytes.Clone(value)
+	return h.tr.TryUpdate(key, value)
+}
+
+// Hash computes the root hash of all inserted key-value pairs.
+func (h *ListHasher) Hash() common.Hash {
+	return h.tr.Hash()
+}

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -165,6 +165,8 @@ func (st *StackTrie) setDb(db ethdb.KeyValueWriter) {
 	}
 }
 
+// setPool recursively assigns the value pool to this node and all of its
+// children, so pooled values can later be released back to the correct pool.
 func (st *StackTrie) setPool(pool *unsafeBytesPool) {
 	st.vPool = pool
 	for _, child := range st.children {
@@ -174,6 +176,9 @@ func (st *StackTrie) setPool(pool *unsafeBytesPool) {
 	}
 }
 
+// newLeaf creates a leaf node holding val. valFromPool reports whether val was
+// obtained from the value pool and therefore must be returned to it when the
+// node is hashed or reset.
 func newLeaf(ko int, key, val []byte, db ethdb.KeyValueWriter, pool *unsafeBytesPool, valFromPool bool) *StackTrie {
 	st := stackTrieFromPool(db)
 	st.vPool = pool
@@ -185,6 +190,7 @@ func newLeaf(ko int, key, val []byte, db ethdb.KeyValueWriter, pool *unsafeBytes
 	return st
 }
 
+// newExt creates an extension node covering the given key chunk.
 func newExt(ko int, key []byte, child *StackTrie, db ethdb.KeyValueWriter, pool *unsafeBytesPool) *StackTrie {
 	st := stackTrieFromPool(db)
 	st.vPool = pool
@@ -216,20 +222,29 @@ func (st *StackTrie) TryUpdate(key, value []byte) error {
 	return nil
 }
 
+// Update inserts a (key, value) pair into the stack trie. The value is copied
+// internally, so the caller is free to reuse or modify it after this returns.
 func (st *StackTrie) Update(key, value []byte) error {
 	return st.TryUpdate(key, value)
 }
 
+// Reset clears the trie state so the instance can be reused as a list hasher,
+// releasing any pooled values while retaining the value pool for later inserts.
 func (st *StackTrie) Reset() {
 	st.reset(true)
 }
 
+// ensurePool lazily initializes the per-trie value pool used to copy inserted
+// values without allocating a fresh buffer for each item.
 func (st *StackTrie) ensurePool() {
 	if st.vPool == nil {
 		st.vPool = newUnsafeBytesPool(300, 20)
 	}
 }
 
+// copyValue copies value into a buffer owned by the trie. The boolean return
+// reports whether the buffer came from the pool and must therefore be released
+// back to the pool once the owning node is hashed or reset.
 func (st *StackTrie) copyValue(value []byte) ([]byte, bool) {
 	if st.vPool == nil {
 		return common.CopyBytes(value), false
@@ -243,6 +258,8 @@ func (st *StackTrie) copyValue(value []byte) ([]byte, bool) {
 	return vBuf, true
 }
 
+// releaseValue returns a pooled value buffer to the pool (when owned) and clears
+// the node's value reference so it is no longer aliased.
 func (st *StackTrie) releaseValue() {
 	if st.valFromPool && st.vPool != nil {
 		st.vPool.put(st.val)
@@ -251,6 +268,9 @@ func (st *StackTrie) releaseValue() {
 	st.valFromPool = false
 }
 
+// reset recursively clears this node and returns its children to the node pool.
+// When keepPool is false the value pool reference is dropped as well; otherwise
+// it is preserved (or lazily recreated) so the trie can be reused.
 func (st *StackTrie) reset(keepPool bool) {
 	for i, child := range st.children {
 		if child != nil {

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -21,13 +21,11 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
-	"fmt"
 	"io"
 	"sync"
 
 	"github.com/morph-l2/go-ethereum/common"
 	"github.com/morph-l2/go-ethereum/ethdb"
-	"github.com/morph-l2/go-ethereum/log"
 	"github.com/morph-l2/go-ethereum/rlp"
 )
 
@@ -46,7 +44,7 @@ func stackTrieFromPool(db ethdb.KeyValueWriter) *StackTrie {
 }
 
 func returnToPool(st *StackTrie) {
-	st.Reset()
+	st.reset(false)
 	stPool.Put(st)
 }
 
@@ -54,12 +52,14 @@ func returnToPool(st *StackTrie) {
 // in order. Once it determines that a subtree will no longer be inserted
 // into, it will hash it and free up the memory it uses.
 type StackTrie struct {
-	nodeType  uint8                // node type (as in branch, ext, leaf)
-	val       []byte               // value contained by this node if it's a leaf
-	key       []byte               // key chunk covered by this (full|ext) node
-	keyOffset int                  // offset of the key chunk inside a full key
-	children  [16]*StackTrie       // list of children (for fullnodes and exts)
-	db        ethdb.KeyValueWriter // Pointer to the commit db, can be nil
+	nodeType    uint8                // node type (as in branch, ext, leaf)
+	val         []byte               // value contained by this node if it's a leaf
+	key         []byte               // key chunk covered by this (full|ext) node
+	keyOffset   int                  // offset of the key chunk inside a full key
+	children    [16]*StackTrie       // list of children (for fullnodes and exts)
+	db          ethdb.KeyValueWriter // Pointer to the commit db, can be nil
+	vPool       *unsafeBytesPool     // Per-root pool for copied list values
+	valFromPool bool                 // Whether val must be returned to vPool
 }
 
 // NewStackTrie allocates and initializes an empty trie.
@@ -67,6 +67,7 @@ func NewStackTrie(db ethdb.KeyValueWriter) *StackTrie {
 	return &StackTrie{
 		nodeType: emptyNode,
 		db:       db,
+		vPool:    newUnsafeBytesPool(300, 20),
 	}
 }
 
@@ -76,6 +77,8 @@ func NewFromBinary(data []byte, db ethdb.KeyValueWriter) (*StackTrie, error) {
 	if err := st.UnmarshalBinary(data); err != nil {
 		return nil, err
 	}
+	st.vPool = newUnsafeBytesPool(300, 20)
+	st.setPool(st.vPool)
 	// If a database is used, we need to recursively add it to every child
 	if db != nil {
 		st.setDb(db)
@@ -133,7 +136,9 @@ func (st *StackTrie) unmarshalBinary(r io.Reader) error {
 	}
 	gob.NewDecoder(r).Decode(&dec)
 	st.nodeType = dec.Nodetype
+	st.releaseValue()
 	st.val = dec.Val
+	st.valFromPool = false
 	st.key = dec.Key
 	st.keyOffset = int(dec.KeyOffset)
 
@@ -160,17 +165,29 @@ func (st *StackTrie) setDb(db ethdb.KeyValueWriter) {
 	}
 }
 
-func newLeaf(ko int, key, val []byte, db ethdb.KeyValueWriter) *StackTrie {
+func (st *StackTrie) setPool(pool *unsafeBytesPool) {
+	st.vPool = pool
+	for _, child := range st.children {
+		if child != nil {
+			child.setPool(pool)
+		}
+	}
+}
+
+func newLeaf(ko int, key, val []byte, db ethdb.KeyValueWriter, pool *unsafeBytesPool, valFromPool bool) *StackTrie {
 	st := stackTrieFromPool(db)
+	st.vPool = pool
 	st.nodeType = leafNode
 	st.keyOffset = ko
 	st.key = append(st.key, key[ko:]...)
 	st.val = val
+	st.valFromPool = valFromPool
 	return st
 }
 
-func newExt(ko int, key []byte, child *StackTrie, db ethdb.KeyValueWriter) *StackTrie {
+func newExt(ko int, key []byte, child *StackTrie, db ethdb.KeyValueWriter, pool *unsafeBytesPool) *StackTrie {
 	st := stackTrieFromPool(db)
+	st.vPool = pool
 	st.nodeType = extNode
 	st.keyOffset = ko
 	st.key = append(st.key, key[ko:]...)
@@ -189,26 +206,66 @@ const (
 
 // TryUpdate inserts a (key, value) pair into the stack trie
 func (st *StackTrie) TryUpdate(key, value []byte) error {
-	k := keybytesToHex(key)
 	if len(value) == 0 {
-		panic("deletion not supported")
+		return errors.New("deletion not supported")
 	}
-	st.insert(k[:len(k)-1], value)
+	st.ensurePool()
+	k := keybytesToHex(key)
+	v, fromPool := st.copyValue(value)
+	st.insert(k[:len(k)-1], v, fromPool)
 	return nil
 }
 
-func (st *StackTrie) Update(key, value []byte) {
-	if err := st.TryUpdate(key, value); err != nil {
-		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
-	}
+func (st *StackTrie) Update(key, value []byte) error {
+	return st.TryUpdate(key, value)
 }
 
 func (st *StackTrie) Reset() {
+	st.reset(true)
+}
+
+func (st *StackTrie) ensurePool() {
+	if st.vPool == nil {
+		st.vPool = newUnsafeBytesPool(300, 20)
+	}
+}
+
+func (st *StackTrie) copyValue(value []byte) ([]byte, bool) {
+	if st.vPool == nil {
+		return common.CopyBytes(value), false
+	}
+	vBuf := st.vPool.get()
+	if cap(vBuf) < len(value) {
+		return common.CopyBytes(value), false
+	}
+	vBuf = vBuf[:len(value)]
+	copy(vBuf, value)
+	return vBuf, true
+}
+
+func (st *StackTrie) releaseValue() {
+	if st.valFromPool && st.vPool != nil {
+		st.vPool.put(st.val)
+	}
+	st.val = nil
+	st.valFromPool = false
+}
+
+func (st *StackTrie) reset(keepPool bool) {
+	for i, child := range st.children {
+		if child != nil {
+			child.reset(false)
+			stPool.Put(child)
+			st.children[i] = nil
+		}
+	}
+	st.releaseValue()
 	st.db = nil
 	st.key = st.key[:0]
-	st.val = nil
-	for i := range st.children {
-		st.children[i] = nil
+	if !keepPool {
+		st.vPool = nil
+	} else if st.vPool == nil {
+		st.vPool = newUnsafeBytesPool(300, 20)
 	}
 	st.nodeType = emptyNode
 	st.keyOffset = 0
@@ -226,7 +283,7 @@ func (st *StackTrie) getDiffIndex(key []byte) int {
 
 // Helper function to that inserts a (key, value) pair into
 // the trie.
-func (st *StackTrie) insert(key, value []byte) {
+func (st *StackTrie) insert(key, value []byte, valueFromPool bool) {
 	switch st.nodeType {
 	case branchNode: /* Branch */
 		idx := int(key[st.keyOffset])
@@ -242,9 +299,12 @@ func (st *StackTrie) insert(key, value []byte) {
 		// Add new child
 		if st.children[idx] == nil {
 			st.children[idx] = stackTrieFromPool(st.db)
+			st.children[idx].vPool = st.vPool
 			st.children[idx].keyOffset = st.keyOffset + 1
+		} else if st.children[idx].vPool == nil {
+			st.children[idx].setPool(st.vPool)
 		}
-		st.children[idx].insert(key, value)
+		st.children[idx].insert(key, value, valueFromPool)
 	case extNode: /* Ext */
 		// Compare both key chunks and see where they differ
 		diffidx := st.getDiffIndex(key)
@@ -257,7 +317,10 @@ func (st *StackTrie) insert(key, value []byte) {
 		if diffidx == len(st.key) {
 			// Ext key and key segment are identical, recurse into
 			// the child node.
-			st.children[0].insert(key, value)
+			if st.children[0].vPool == nil {
+				st.children[0].setPool(st.vPool)
+			}
+			st.children[0].insert(key, value, valueFromPool)
 			return
 		}
 		// Save the original part. Depending if the break is
@@ -266,7 +329,7 @@ func (st *StackTrie) insert(key, value []byte) {
 		// node directly.
 		var n *StackTrie
 		if diffidx < len(st.key)-1 {
-			n = newExt(diffidx+1, st.key, st.children[0], st.db)
+			n = newExt(diffidx+1, st.key, st.children[0], st.db, st.vPool)
 		} else {
 			// Break on the last byte, no need to insert
 			// an extension node: reuse the current node
@@ -287,12 +350,13 @@ func (st *StackTrie) insert(key, value []byte) {
 			// long, insert a new intermediate branch
 			// node.
 			st.children[0] = stackTrieFromPool(st.db)
+			st.children[0].vPool = st.vPool
 			st.children[0].nodeType = branchNode
 			st.children[0].keyOffset = st.keyOffset + diffidx
 			p = st.children[0]
 		}
 		// Create a leaf for the inserted part
-		o := newLeaf(st.keyOffset+diffidx+1, key, value, st.db)
+		o := newLeaf(st.keyOffset+diffidx+1, key, value, st.db, st.vPool, valueFromPool)
 
 		// Insert both child leaves where they belong:
 		origIdx := st.key[diffidx]
@@ -328,7 +392,8 @@ func (st *StackTrie) insert(key, value []byte) {
 			// Convert current node into an ext,
 			// and insert a child branch node.
 			st.nodeType = extNode
-			st.children[0] = NewStackTrie(st.db)
+			st.children[0] = stackTrieFromPool(st.db)
+			st.children[0].vPool = st.vPool
 			st.children[0].nodeType = branchNode
 			st.children[0].keyOffset = st.keyOffset + diffidx
 			p = st.children[0]
@@ -339,20 +404,22 @@ func (st *StackTrie) insert(key, value []byte) {
 		// The child leave will be hashed directly in order to
 		// free up some memory.
 		origIdx := st.key[diffidx]
-		p.children[origIdx] = newLeaf(diffidx+1, st.key, st.val, st.db)
+		p.children[origIdx] = newLeaf(diffidx+1, st.key, st.val, st.db, st.vPool, st.valFromPool)
+		st.val = nil
+		st.valFromPool = false
 		p.children[origIdx].hash()
 
 		newIdx := key[diffidx+st.keyOffset]
-		p.children[newIdx] = newLeaf(p.keyOffset+1, key, value, st.db)
+		p.children[newIdx] = newLeaf(p.keyOffset+1, key, value, st.db, st.vPool, valueFromPool)
 
 		// Finally, cut off the key part that has been passed
 		// over to the children.
 		st.key = st.key[:diffidx]
-		st.val = nil
 	case emptyNode: /* Empty */
 		st.nodeType = leafNode
 		st.key = key[st.keyOffset:]
 		st.val = value
+		st.valFromPool = valueFromPool
 	case hashedNode:
 		panic("trying to insert into hash")
 	default:
@@ -442,6 +509,7 @@ func (st *StackTrie) hash() {
 		}
 	case emptyNode:
 		st.val = emptyRoot.Bytes()
+		st.valFromPool = false
 		st.key = st.key[:0]
 		st.nodeType = hashedNode
 		return
@@ -450,20 +518,21 @@ func (st *StackTrie) hash() {
 	}
 	st.key = st.key[:0]
 	st.nodeType = hashedNode
+	st.releaseValue()
 	if len(h.tmp) < 32 {
 		st.val = common.CopyBytes(h.tmp)
+		st.valFromPool = false
 		return
 	}
 	// Write the hash to the 'val'. We allocate a new val here to not mutate
 	// input values
 	st.val = make([]byte, 32)
+	st.valFromPool = false
 	h.sha.Reset()
 	h.sha.Write(h.tmp)
 	h.sha.Read(st.val)
 	if st.db != nil {
-		// TODO! Is it safe to Put the slice here?
-		// Do all db implementations copy the value provided?
-		st.db.Put(st.val, h.tmp)
+		st.db.Put(st.val, common.CopyBytes(h.tmp))
 	}
 }
 
@@ -507,7 +576,7 @@ func (st *StackTrie) Commit() (common.Hash, error) {
 		h.sha.Reset()
 		h.sha.Write(st.val)
 		h.sha.Read(ret)
-		st.db.Put(ret, st.val)
+		st.db.Put(ret, common.CopyBytes(st.val))
 		return common.BytesToHash(ret), nil
 	}
 	return common.BytesToHash(st.val), nil

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -451,7 +451,9 @@ func TestStacktrieSerialization(t *testing.T) {
 		keyDelta.Add(keyDelta, common.Big1)
 	}
 	for i, k := range keys {
-		nt.TryUpdate(k, vals[i])
+		if err := nt.TryUpdate(k, vals[i]); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	for i, k := range keys {
@@ -464,7 +466,9 @@ func TestStacktrieSerialization(t *testing.T) {
 			t.Fatal(err)
 		}
 		st = newSt
-		st.TryUpdate(k, vals[i])
+		if err := st.TryUpdate(k, vals[i]); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if have, want := st.Hash(), nt.Hash(); have != want {
 		t.Fatalf("have %#x want %#x", have, want)

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -347,6 +347,85 @@ func TestStacktrieNotModifyValues(t *testing.T) {
 	}
 }
 
+func TestStackTrieUpdateCopiesValue(t *testing.T) {
+	st := NewStackTrie(nil)
+	nt, _ := New(common.Hash{}, NewDatabase(memorydb.New()))
+
+	key1, key2 := []byte{0x01}, []byte{0x02}
+	value1, value2 := []byte("value-one"), []byte("value-two")
+	nt.TryUpdate(key1, common.CopyBytes(value1))
+	nt.TryUpdate(key2, common.CopyBytes(value2))
+
+	if err := st.TryUpdate(key1, value1); err != nil {
+		t.Fatal(err)
+	}
+	for i := range value1 {
+		value1[i] ^= 0xff
+	}
+	if err := st.TryUpdate(key2, value2); err != nil {
+		t.Fatal(err)
+	}
+	if have, want := st.Hash(), nt.Hash(); have != want {
+		t.Fatalf("root mismatch after mutating caller value: have %x want %x", have, want)
+	}
+}
+
+func TestStackTrieUpdateCopiesKey(t *testing.T) {
+	st := NewStackTrie(nil)
+	nt, _ := New(common.Hash{}, NewDatabase(memorydb.New()))
+
+	key1, key2 := []byte{0x01}, []byte{0x02}
+	value1, value2 := []byte("value-one"), []byte("value-two")
+	nt.TryUpdate(common.CopyBytes(key1), common.CopyBytes(value1))
+	nt.TryUpdate(common.CopyBytes(key2), common.CopyBytes(value2))
+
+	if err := st.TryUpdate(key1, value1); err != nil {
+		t.Fatal(err)
+	}
+	key1[0] = 0xff
+	if err := st.TryUpdate(key2, value2); err != nil {
+		t.Fatal(err)
+	}
+	if have, want := st.Hash(), nt.Hash(); have != want {
+		t.Fatalf("root mismatch after mutating caller key: have %x want %x", have, want)
+	}
+}
+
+func TestStackTrieResetListHasherReuse(t *testing.T) {
+	st := NewStackTrie(nil)
+	if err := st.TryUpdate([]byte{0x01}, []byte("first")); err != nil {
+		t.Fatal(err)
+	}
+	st.Hash()
+	st.Reset()
+
+	nt, _ := New(common.Hash{}, NewDatabase(memorydb.New()))
+	nt.TryUpdate([]byte{0x02}, []byte("second"))
+	if err := st.TryUpdate([]byte{0x02}, []byte("second")); err != nil {
+		t.Fatal(err)
+	}
+	if have, want := st.Hash(), nt.Hash(); have != want {
+		t.Fatalf("root mismatch after reset reuse: have %x want %x", have, want)
+	}
+}
+
+func TestStackTrieResetBeforeHashReleasesOwnedValues(t *testing.T) {
+	st := NewStackTrie(nil)
+	if err := st.TryUpdate([]byte{0x01}, []byte("stale-value")); err != nil {
+		t.Fatal(err)
+	}
+	st.Reset()
+
+	nt, _ := New(common.Hash{}, NewDatabase(memorydb.New()))
+	nt.TryUpdate([]byte{0x02}, []byte("fresh-value"))
+	if err := st.TryUpdate([]byte{0x02}, []byte("fresh-value")); err != nil {
+		t.Fatal(err)
+	}
+	if have, want := st.Hash(), nt.Hash(); have != want {
+		t.Fatalf("root mismatch after reset before hash: have %x want %x", have, want)
+	}
+}
+
 // TestStacktrieSerialization tests that the stacktrie works well if we
 // serialize/unserialize it a lot
 func TestStacktrieSerialization(t *testing.T) {
@@ -372,7 +451,7 @@ func TestStacktrieSerialization(t *testing.T) {
 		keyDelta.Add(keyDelta, common.Big1)
 	}
 	for i, k := range keys {
-		nt.TryUpdate(k, common.CopyBytes(vals[i]))
+		nt.TryUpdate(k, vals[i])
 	}
 
 	for i, k := range keys {
@@ -385,7 +464,7 @@ func TestStacktrieSerialization(t *testing.T) {
 			t.Fatal(err)
 		}
 		st = newSt
-		st.TryUpdate(k, common.CopyBytes(vals[i]))
+		st.TryUpdate(k, vals[i])
 	}
 	if have, want := st.Hash(), nt.Hash(); have != want {
 		t.Fatalf("have %#x want %#x", have, want)


### PR DESCRIPTION
## Summary
- Migrates `DeriveSha` from the old `TrieHasher` contract to the upstream-style `ListHasher` contract where hashers copy input key/value slices.
- Adds `trie.NewListHasher()` as a correctness oracle and moves StackTrie value ownership into an internal `unsafeBytesPool` so DeriveSha can reuse its encoding buffer safely.
- Preserves Morph StackTrie DB commit and serialization behavior, with regression tests for key/value aliasing, reset reuse, and typed tx/receipt roots.

## Test plan
- [x] `go test ./core/types/... ./trie/... -run 'TestDeriveSha|TestEIP2718DeriveSha|TestFuzzDeriveSha|TestDerivableList|TestStackTrie|TestStacktrie'`
- [x] `go test ./consensus/... ./core/rawdb/... ./internal/ethapi/... -run 'Test.*Block|Test.*Receipt|Test.*Derive|TestLookup'`
- [x] `go test ./core/types/... -run '^$' -bench BenchmarkDeriveSha -benchmem -count=5`
- [ ] `go test ./eth/... ./les/... ./cmd/evm/... -run 'Test.*Derive|Test.*Receipt|Test.*Block'` partially passes; `les` ODR/access tests fail with genesis mismatch that reproduces on rerun and changes hashes between runs.
- [ ] `go build ./...` currently fails in external dependency `golang.org/x/tools/internal/tokeninternal` due to the local Go/toolchain compile-time check.

Fixes #336

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction/receipt hash derivation now uses list-based hashing with a dedicated list-hasher implementation for consistent root computation.
* **Bug Fixes**
  * StackTrie updates no longer panic on zero-length values; update operations now return errors instead.
  * Improved buffer ownership and added copying at commit time to prevent unintended memory aliasing.
* **Performance**
  * Added byte-slice pooling to reduce allocations during trie operations.
* **Tests**
  * Expanded hashing and StackTrie tests, including reset/reuse and key/value copy semantics across typed transaction/receipt variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->