### PR TITLE
fix(fees): round AltToEth down (floor) instead of up

### DIFF
--- a/core/types/token_fee.go
+++ b/core/types/token_fee.go
@@ -66,6 +66,17 @@ func EthToAlt(ethAmount, rate, tokenScale *big.Int) (*big.Int, error) {
 }
 
 // AltToEth ethAmount = altAmount * (tokenRate / tokenScale)
+//
+// Rounds DOWN (floor). AltToEth converts a user's token balance into the
+// ETH-equivalent budget used to cap the gas allowance in estimation
+// (eth_estimateGas / eth_call). Fees are actually charged at execution via
+// EthToAlt, which rounds UP: paying for G wei of gas costs
+// ceil(G*tokenScale/rate) tokens. The largest ETH fee a balance `a` can cover
+// is therefore exactly floor(a*rate/tokenScale) — the floor here is the exact
+// inverse of EthToAlt's ceiling. Rounding up would credit up to 1 wei more
+// than the user can actually pay, over-stating the allowance and producing
+// estimates that fail at execution. Floor also matches morph-reth's
+// token_amount_to_eth, keeping the two clients' estimates consistent.
 func AltToEth(erc20Amount, rate, tokenScale *big.Int) (*big.Int, error) {
 	if rate == nil || rate.Sign() <= 0 {
 		return nil, errors.New("invalid rate")
@@ -73,11 +84,5 @@ func AltToEth(erc20Amount, rate, tokenScale *big.Int) (*big.Int, error) {
 	if tokenScale == nil || tokenScale.Sign() <= 0 {
 		return nil, errors.New("invalid token scale")
 	}
-	ethAmount := new(big.Int)
-	remainder := new(big.Int)
-	ethAmount.QuoRem(new(big.Int).Mul(erc20Amount, rate), tokenScale, remainder)
-	if remainder.Sign() != 0 {
-		ethAmount.Add(ethAmount, big.NewInt(1))
-	}
-	return ethAmount, nil
+	return new(big.Int).Quo(new(big.Int).Mul(erc20Amount, rate), tokenScale), nil
 }

--- a/core/types/token_fee_test.go
+++ b/core/types/token_fee_test.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAltToEthFloorRounding asserts AltToEth rounds DOWN. A token balance whose
+// ETH-equivalent has a non-zero remainder must not be rounded up: rounding up
+// would credit more ETH budget than the user can actually pay for at execution
+// (where EthToAlt rounds up).
+func TestAltToEthFloorRounding(t *testing.T) {
+	cases := []struct {
+		name               string
+		erc20, rate, scale int64
+		want               int64
+	}{
+		{"exact division, no remainder", 4, 2, 2, 4}, // 4*2/2 = 4
+		{"remainder rounds down", 5, 3, 2, 7},        // 15/2 = 7.5 -> floor 7 (was 8 under ceiling)
+		{"remainder rounds down 2", 7, 3, 2, 10},     // 21/2 = 10.5 -> floor 10
+		{"scale larger than product", 1, 1, 4, 0},    // 1/4 = 0.25 -> floor 0
+		{"zero balance", 0, 3, 2, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := AltToEth(big.NewInt(c.erc20), big.NewInt(c.rate), big.NewInt(c.scale))
+			require.NoError(t, err)
+			require.Equal(t, big.NewInt(c.want), got)
+		})
+	}
+}
+
+// TestEthToAltCeilRounding is a regression guard that the charging direction
+// (EthToAlt) still rounds UP — the fee gate must never under-charge.
+func TestEthToAltCeilRounding(t *testing.T) {
+	cases := []struct {
+		name             string
+		eth, rate, scale int64
+		want             int64
+	}{
+		{"exact division, no remainder", 6, 3, 2, 4}, // 6*2/3 = 4
+		{"remainder rounds up", 5, 3, 2, 4},          // 10/3 = 3.33 -> ceil 4
+		{"remainder rounds up 2", 7, 3, 2, 5},        // 14/3 = 4.67 -> ceil 5
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := EthToAlt(big.NewInt(c.eth), big.NewInt(c.rate), big.NewInt(c.scale))
+			require.NoError(t, err)
+			require.Equal(t, big.NewInt(c.want), got)
+		})
+	}
+}
+
+// TestAltToEthIsExactInverseOfEthToAlt verifies the load-bearing invariant: for
+// any token balance a, AltToEth(a) is EXACTLY the maximum ETH fee the balance
+// can cover under EthToAlt-ceiling charging. That is, EthToAlt(AltToEth(a)) <= a
+// (affordable) while EthToAlt(AltToEth(a)+1) > a (one wei more is not). This is
+// what makes the estimation allowance agree with execution with no gap and no
+// over-credit.
+func TestAltToEthIsExactInverseOfEthToAlt(t *testing.T) {
+	rates := []int64{1, 2, 3, 5, 7}
+	scales := []int64{1, 2, 3, 4, 6}
+	for _, rate := range rates {
+		for _, scale := range scales {
+			for a := int64(0); a <= 50; a++ {
+				bal := big.NewInt(a)
+				r := big.NewInt(rate)
+				s := big.NewInt(scale)
+
+				ethBudget, err := AltToEth(bal, r, s)
+				require.NoError(t, err)
+
+				costAtBudget, err := EthToAlt(ethBudget, r, s)
+				require.NoError(t, err)
+				require.True(t, costAtBudget.Cmp(bal) <= 0,
+					"AltToEth(%d) budget %s must be affordable: EthToAlt=%s > balance %d (rate=%d scale=%d)",
+					a, ethBudget, costAtBudget, a, rate, scale)
+
+				costAboveBudget, err := EthToAlt(new(big.Int).Add(ethBudget, big.NewInt(1)), r, s)
+				require.NoError(t, err)
+				require.True(t, costAboveBudget.Cmp(bal) > 0,
+					"AltToEth(%d) must be the MAX affordable budget: budget+1 (%s) still affordable at balance %d (rate=%d scale=%d)",
+					a, new(big.Int).Add(ethBudget, big.NewInt(1)), a, rate, scale)
+			}
+		}
+	}
+}
+
+// TestTokenFeeConversionInvalidArgs covers the guard clauses for both directions.
+func TestTokenFeeConversionInvalidArgs(t *testing.T) {
+	valid := big.NewInt(1)
+	for _, tc := range []struct {
+		name        string
+		rate, scale *big.Int
+	}{
+		{"nil rate", nil, valid},
+		{"zero rate", big.NewInt(0), valid},
+		{"negative rate", big.NewInt(-1), valid},
+		{"nil scale", valid, nil},
+		{"zero scale", valid, big.NewInt(0)},
+		{"negative scale", valid, big.NewInt(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := AltToEth(big.NewInt(10), tc.rate, tc.scale)
+			require.Error(t, err)
+			_, err = EthToAlt(big.NewInt(10), tc.rate, tc.scale)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Closes #353. Fixes the rounding direction of `core/types/token_fee.go::AltToEth`, which over-states the token-fee gas allowance in `eth_estimateGas` / `eth_call` and diverges from morph-reth (audit Issue-5).

`AltToEth` converts a user's ERC20 token balance into the ETH-equivalent budget used to cap the gas allowance (its only caller is `fees.AltToETH` in `internal/ethapi/api.go:1401`). It is **not on any consensus path**. Fees are charged at execution by `EthToAlt`, which rounds **up**: paying for `G` wei of gas costs `ceil(G*tokenScale/rate)` tokens (`core/state_transition.go::buyGas`). The maximum ETH fee a balance `a` can cover is therefore exactly `floor(a*rate/tokenScale)` — so `AltToEth` must round **down** to be the exact inverse of `EthToAlt`'s ceiling.

Previously `AltToEth` rounded up, crediting up to 1 wei more than the user can actually pay → the allowance can be 1 gas too high → estimates that fail at execution. Floor also matches reth's `token_amount_to_eth`, resolving the cross-client divergence in the **correct** direction (align to floor, not ceiling as the audit initially suggested).

`EthToAlt` (the charge gate) is intentionally left rounding up — the user must never be under-charged. The asymmetry (charge up, credit down) is the conservative, consistent design.

Worked example (`rate=3, scale=2, balance=5`): old `AltToEth=ceil(15/2)=8`, but `EthToAlt(8)=ceil(16/3)=6 > 5` (unpayable). New `AltToEth=floor=7`, and `EthToAlt(7)=5 ≤ 5` (exactly affordable).

### Tests
- `TestAltToEthFloorRounding` — floor result for remainder cases (`5,3,2 -> 7`, not 8).
- `TestEthToAltCeilRounding` — regression guard that the charge gate still ceils.
- `TestAltToEthIsExactInverseOfEthToAlt` — invariant `EthToAlt(AltToEth(a)) <= a < EthToAlt(AltToEth(a)+1)` across a range of rates/scales.
- `TestTokenFeeConversionInvalidArgs` — guard clauses.

## 2. PR title

- [x] fix: A bug fix

## 3. Deployment tag versioning

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces

## 4. Breaking change label

- [x] This PR is not a breaking change

---

Note: the commit is unsigned (GPG signing was unavailable in the authoring session) — re-sign on merge if branch protection requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated token amount-to-ETH conversion calculation to use floor rounding (rounding down) instead of ceiling rounding, ensuring more consistent and accurate gas fee estimations when converting between token amounts and their ETH equivalents.

* **Tests**
  * Added comprehensive test coverage for token-to-ETH conversion rounding behavior, edge cases, argument validation, and conversion accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->