### PR TITLE
fix: align sentry txpool and log range handling

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -311,7 +311,8 @@ func (l *txList) Add(tx *types.Transaction, state *state.StateDB, priceBump uint
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
-		if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
+		zeroTipReplacement := old.GasTipCap().Sign() == 0 && tx.GasTipCap().Sign() == 0
+		if old.GasFeeCapCmp(tx) >= 0 || (!zeroTipReplacement && old.GasTipCapCmp(tx) >= 0) {
 			return false, nil
 		}
 		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
@@ -327,7 +328,7 @@ func (l *txList) Add(tx *types.Transaction, state *state.StateDB, priceBump uint
 		// We have to ensure that both the new fee cap and tip are higher than the
 		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements.
-		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
+		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || (!zeroTipReplacement && tx.GasTipCapIntCmp(thresholdTip) < 0) {
 			return false, nil
 		}
 	}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2356,6 +2356,86 @@ func TestTransactionReplacementDynamicFee(t *testing.T) {
 	}
 }
 
+func TestTransactionReplacementDynamicFeeZeroTip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		oldFeeCap      int64
+		oldTipCap      int64
+		newFeeCap      int64
+		newTipCap      int64
+		wantErr        error
+		validateEvents bool
+	}{
+		{
+			name:           "zero tip fee bump accepted",
+			oldFeeCap:      2_000_000,
+			newFeeCap:      4_000_000,
+			validateEvents: true,
+		},
+		{
+			name:      "zero tip insufficient fee bump rejected",
+			oldFeeCap: 2_000_000,
+			newFeeCap: 2_100_000,
+			wantErr:   ErrReplaceUnderpriced,
+		},
+		{
+			name:      "nonzero tip requires tip bump",
+			oldFeeCap: 2_000_000,
+			oldTipCap: 100,
+			newFeeCap: 4_000_000,
+			newTipCap: 100,
+			wantErr:   ErrReplaceUnderpriced,
+		},
+		{
+			name:           "nonzero tip accepts dual bump",
+			oldFeeCap:      2_000_000,
+			oldTipCap:      100,
+			newFeeCap:      4_000_000,
+			newTipCap:      110,
+			validateEvents: true,
+		},
+	}
+	for _, stage := range []string{"pending", "queued"} {
+		for _, tt := range tests {
+			t.Run(stage+"/"+tt.name, func(t *testing.T) {
+				pool, key := setupTxPoolWithConfig(eip1559NoL1feeConfig)
+				defer pool.Stop()
+				testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1_000_000_000_000_000_000))
+
+				events := make(chan NewTxsEvent, 32)
+				sub := pool.txFeed.Subscribe(events)
+				defer sub.Unsubscribe()
+
+				nonce := uint64(0)
+				if stage == "queued" {
+					nonce = 2
+				}
+				if err := pool.addRemoteSync(dynamicFeeTx(nonce, 100000, big.NewInt(tt.oldFeeCap), big.NewInt(tt.oldTipCap), key)); err != nil {
+					t.Fatalf("failed to add original %s transaction: %v", stage, err)
+				}
+				err := pool.AddRemote(dynamicFeeTx(nonce, 100000, big.NewInt(tt.newFeeCap), big.NewInt(tt.newTipCap), key))
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("replacement error mismatch: have %v, want %v", err, tt.wantErr)
+				}
+				if tt.validateEvents {
+					count := 2
+					if stage == "queued" {
+						count = 0
+					}
+					if err := validateEvents(events, count); err != nil {
+						t.Fatalf("replacement event firing failed: %v", err)
+					}
+				}
+				if err := validateTxPoolInternals(pool); err != nil {
+					t.Fatalf("pool internal state corrupted: %v", err)
+				}
+			})
+		}
+	}
+}
+
 // Tests that local transactions are journaled to disk, but remote transactions
 // get discarded between restarts.
 func TestTransactionJournaling(t *testing.T)         { testTransactionJournaling(t, false) }

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -39,10 +39,27 @@ const maxTxHashes = 200
 const maxTopics = 4
 
 var (
-  errExceedMaxTxHashes   = errors.New("exceed maximum transaction hash count")
+	errInvalidBlockRange   = invalidParamsErr("invalid block range params")
+	errExceedMaxTxHashes   = errors.New("exceed maximum transaction hash count")
 	errExceedMaxTopics     = errors.New("exceed max topics")
 	errExceedLogQueryLimit = errors.New("exceed max addresses or topics per search position")
 )
+
+type invalidParamsError struct {
+	err error
+}
+
+func invalidParamsErr(msg string) invalidParamsError {
+	return invalidParamsError{err: errors.New(msg)}
+}
+
+func (e invalidParamsError) Error() string {
+	return e.err.Error()
+}
+
+func (e invalidParamsError) ErrorCode() int {
+	return -32602
+}
 
 // filter is a helper struct that holds meta information over the filter type
 // and associated subscription in the event system.
@@ -457,6 +474,10 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*type
 		end := rpc.LatestBlockNumber.Int64()
 		if crit.ToBlock != nil {
 			end = crit.ToBlock.Int64()
+		}
+		// Block numbers below 0 are special cases.
+		if begin > 0 && end > 0 && begin > end {
+			return nil, errInvalidBlockRange
 		}
 		// Construct the range filter
 		filter = api.sys.NewRangeFilter(begin, end, crit.Addresses, crit.Topics, api.maxBlockRange)

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -216,7 +216,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	}
 
 	if begin > end {
-		return nil, nil
+		return nil, errInvalidBlockRange
 	}
 	f.begin = int64(begin)
 	f.end = int64(end)

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -809,6 +809,26 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 	}
 }
 
+func TestInvalidGetRangeLogsRequest(t *testing.T) {
+	var (
+		db     = rawdb.NewMemoryDatabase()
+		_, sys = newTestFilterSystem(t, db, Config{})
+		api    = NewFilterAPI(sys, false, ethconfig.Defaults.MaxBlockRange)
+	)
+	crit := FilterCriteria{FromBlock: big.NewInt(2), ToBlock: big.NewInt(1)}
+
+	if _, err := api.GetLogs(context.Background(), crit); err != errInvalidBlockRange {
+		t.Fatalf("GetLogs error mismatch: have %v, want %v", err, errInvalidBlockRange)
+	} else if rpcErr, ok := err.(rpc.Error); !ok || rpcErr.ErrorCode() != -32602 {
+		t.Fatalf("GetLogs RPC error code mismatch: have %v, want -32602", err)
+	}
+
+	filter := api.sys.NewRangeFilter(2, 1, nil, nil, ethconfig.Defaults.MaxBlockRange)
+	if _, err := filter.Logs(context.Background()); err != errInvalidBlockRange {
+		t.Fatalf("Filter.Logs error mismatch: have %v, want %v", err, errInvalidBlockRange)
+	}
+}
+
 func TestExceedLogQueryLimit(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
 	_, sys := newTestFilterSystem(t, db, Config{LogQueryLimit: 1})

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -823,6 +823,16 @@ func TestInvalidGetRangeLogsRequest(t *testing.T) {
 		t.Fatalf("GetLogs RPC error code mismatch: have %v, want -32602", err)
 	}
 
+	// toBlock=0 (earliest) bypasses the `begin > 0 && end > 0` early-exit (kept
+	// verbatim with upstream geth), but the inverted range must still be rejected
+	// by the low-level range check with the same -32602 error.
+	critZeroTo := FilterCriteria{FromBlock: big.NewInt(1), ToBlock: big.NewInt(0)}
+	if _, err := api.GetLogs(context.Background(), critZeroTo); err != errInvalidBlockRange {
+		t.Fatalf("GetLogs(from=1,to=0) error mismatch: have %v, want %v", err, errInvalidBlockRange)
+	} else if rpcErr, ok := err.(rpc.Error); !ok || rpcErr.ErrorCode() != -32602 {
+		t.Fatalf("GetLogs(from=1,to=0) RPC error code mismatch: have %v, want -32602", err)
+	}
+
 	filter := api.sys.NewRangeFilter(2, 1, nil, nil, ethconfig.Defaults.MaxBlockRange)
 	if _, err := filter.Logs(context.Background()); err != errInvalidBlockRange {
 		t.Fatalf("Filter.Logs error mismatch: have %v, want %v", err, errInvalidBlockRange)


### PR DESCRIPTION
## Summary
- Return `-32602 invalid block range params` for reversed `eth_getLogs` block ranges, matching upstream geth/reth.
- Allow zero-tip dynamic fee replacements to bump only `maxFeePerGas`, matching reth's txpool policy while preserving strict dual-bump checks for nonzero tips.
- Add focused regression coverage for both D2 and E1 across the affected paths.

Fixes #358

## Test plan
- `go test ./eth/filters -run 'TestInvalid.*Logs|TestGetLogs' -count=1`
- `go test ./core -run 'TestTransactionReplacement' -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction replacement handling for low- or zero-tip fee bump scenarios, making some replacements accept correctly instead of being rejected too early.
  * Log queries now return a clear error when the requested block range is invalid, rather than failing silently.
* **Tests**
  * Added coverage for zero-tip transaction replacement behavior and invalid log range requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->