### PR TITLE
feat: implement EIP-7623 calldata floor gas

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -54,6 +54,7 @@ var (
 			utils.OverrideViridianTimeFlag,
 			utils.OverrideEmeraldTimeFlag,
 			utils.OverrideJadeForkTimeFlag,
+			utils.OverrideNextForkTimeFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
@@ -229,6 +230,10 @@ func initGenesis(ctx *cli.Context) error {
 	if ctx.IsSet(utils.OverrideJadeForkTimeFlag.Name) {
 		v := ctx.Uint64(utils.OverrideJadeForkTimeFlag.Name)
 		overrides.JadeForkTime = &v
+	}
+	if ctx.IsSet(utils.OverrideNextForkTimeFlag.Name) {
+		v := ctx.Uint64(utils.OverrideNextForkTimeFlag.Name)
+		overrides.NextForkTime = &v
 	}
 
 	for _, name := range []string{"chaindata", "lightchaindata"} {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -174,6 +174,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Uint64(utils.OverrideJadeForkTimeFlag.Name)
 		cfg.Eth.OverrideJadeForkTime = &v
 	}
+	if ctx.GlobalIsSet(utils.OverrideNextForkTimeFlag.Name) {
+		v := ctx.Uint64(utils.OverrideNextForkTimeFlag.Name)
+		cfg.Eth.OverrideNextForkTime = &v
+	}
 
 	backend, _ := utils.RegisterEthService(stack, &cfg.Eth)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -75,6 +75,7 @@ var (
 		utils.OverrideViridianTimeFlag,
 		utils.OverrideEmeraldTimeFlag,
 		utils.OverrideJadeForkTimeFlag,
+		utils.OverrideNextForkTimeFlag,
 		utils.OverrideGenesisFlag,
 		utils.EthashCacheDirFlag,
 		utils.EthashCachesInMemoryFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -292,6 +292,10 @@ var (
 		Name:  "override.jadeforktime",
 		Usage: "Manually specify the Jade fork timestamp, overriding the bundled setting",
 	}
+	OverrideNextForkTimeFlag = &cli.Uint64Flag{
+		Name:  "override.nextforktime",
+		Usage: "Manually specify the NextFork timestamp, overriding the bundled setting",
+	}
 	// Light server and client settings
 	LightServeFlag = cli.IntFlag{
 		Name:  "light.serve",
@@ -574,7 +578,7 @@ var (
 	RPCTxSyncEnabledFlag = cli.BoolTFlag{
 		Name:  "rpc.txsync.enabled",
 		Usage: "Enable eth_sendRawTransactionSync receipt waiting",
-  }
+	}
 	RPCGlobalLogQueryLimit = cli.IntFlag{
 		Name:  "rpc.logquerylimit",
 		Usage: "Maximum number of alternative addresses or topics allowed per search position in eth_getLogs filter criteria (0 = no cap)",

--- a/core/eip7623_test.go
+++ b/core/eip7623_test.go
@@ -1,0 +1,162 @@
+package core
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/morph-l2/go-ethereum/common"
+	"github.com/morph-l2/go-ethereum/core/rawdb"
+	"github.com/morph-l2/go-ethereum/core/state"
+	"github.com/morph-l2/go-ethereum/core/tracing"
+	"github.com/morph-l2/go-ethereum/core/types"
+	"github.com/morph-l2/go-ethereum/core/vm"
+	"github.com/morph-l2/go-ethereum/crypto"
+	"github.com/morph-l2/go-ethereum/params"
+)
+
+func TestFloorDataGas(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want uint64
+	}{
+		{
+			name: "empty calldata",
+			data: nil,
+			want: params.TxGas,
+		},
+		{
+			name: "x18 zero calldata",
+			data: make([]byte, 5000),
+			want: 71000,
+		},
+		{
+			name: "mixed calldata",
+			data: append(bytes.Repeat([]byte{1}, 1000), bytes.Repeat([]byte{0}, 1000)...),
+			want: 71000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FloorDataGas(tt.data)
+			if err != nil {
+				t.Fatalf("FloorDataGas returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("FloorDataGas mismatch: got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTxPoolNextForkFloorDataGas(t *testing.T) {
+	makeConfig := func(nextFork bool) *params.ChainConfig {
+		cfg := params.TestNoL1DataFeeChainConfig.Clone()
+		cfg.BerlinBlock = common.Big0
+		cfg.LondonBlock = common.Big0
+		cfg.JadeForkTime = new(uint64)
+		if nextFork {
+			cfg.NextForkTime = new(uint64)
+		}
+		return cfg
+	}
+	makeDataTx := func(key *ecdsa.PrivateKey, gas uint64) *types.Transaction {
+		tx, err := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(0), gas, big.NewInt(1), make([]byte, 5000)), types.HomesteadSigner{}, key)
+		if err != nil {
+			t.Fatalf("failed to sign tx: %v", err)
+		}
+		return tx
+	}
+
+	for _, tt := range []struct {
+		name     string
+		nextFork bool
+		gas      uint64
+		wantErr  error
+	}{
+		{name: "pre next fork accepts legacy intrinsic", gas: 41000},
+		{name: "next fork rejects below floor", nextFork: true, gas: 41000, wantErr: ErrIntrinsicGas},
+		{name: "next fork rejects one below floor", nextFork: true, gas: 70999, wantErr: ErrIntrinsicGas},
+		{name: "next fork accepts exact floor", nextFork: true, gas: 71000},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, key := setupTxPoolWithConfig(makeConfig(tt.nextFork))
+			defer pool.Stop()
+
+			testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1_000_000_000))
+			err := pool.AddRemote(makeDataTx(key, tt.gas))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("AddRemote error mismatch: got %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTransitionDbNextForkFloorDataGasUsed(t *testing.T) {
+	data := make([]byte, 5000)
+	legacyGas, err := IntrinsicGas(data, nil, nil, false, true, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	floorGas, err := FloorDataGas(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name     string
+		nextFork bool
+		wantGas  uint64
+	}{
+		{name: "pre next fork keeps legacy gas used", wantGas: legacyGas},
+		{name: "next fork clamps gas used to floor", nextFork: true, wantGas: floorGas},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := params.TestNoL1DataFeeChainConfig.Clone()
+			cfg.HomesteadBlock = common.Big0
+			cfg.IstanbulBlock = common.Big0
+			cfg.ShanghaiBlock = common.Big0
+			cfg.JadeForkTime = new(uint64)
+			if tt.nextFork {
+				cfg.NextForkTime = new(uint64)
+			}
+
+			statedb, err := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			from := common.HexToAddress("0x1000000000000000000000000000000000000000")
+			to := common.HexToAddress("0x2000000000000000000000000000000000000000")
+			gasLimit := uint64(100000)
+			gasPrice := big.NewInt(1)
+			statedb.AddBalance(from, new(big.Int).SetUint64(gasLimit), tracing.BalanceChangeUnspecified)
+
+			evm := vm.NewEVM(vm.BlockContext{
+				CanTransfer: CanTransfer,
+				Transfer:    Transfer,
+				GetHash:     func(uint64) common.Hash { return common.Hash{} },
+				Coinbase:    common.Address{},
+				GasLimit:    gasLimit,
+				BlockNumber: common.Big0,
+				Time:        common.Big0,
+				BaseFee:     common.Big0,
+			}, vm.TxContext{
+				Origin:   from,
+				To:       &to,
+				GasPrice: gasPrice,
+			}, statedb, cfg, vm.Config{})
+			msg := types.NewMessage(from, &to, 0, big.NewInt(0), gasLimit, gasPrice, gasPrice, gasPrice, 0, nil, 0, nil, nil, data, nil, nil, false)
+			gp := new(GasPool).AddGas(gasLimit)
+			result, err := NewStateTransition(evm, msg, gp, big.NewInt(0)).TransitionDb()
+			if err != nil {
+				t.Fatalf("TransitionDb returned error: %v", err)
+			}
+			if result.UsedGas != tt.wantGas {
+				t.Fatalf("UsedGas mismatch: got %d, want %d", result.UsedGas, tt.wantGas)
+			}
+		})
+	}
+}

--- a/core/eip7623_test.go
+++ b/core/eip7623_test.go
@@ -107,12 +107,14 @@ func TestTransitionDbNextForkFloorDataGasUsed(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name     string
-		nextFork bool
-		wantGas  uint64
+		name      string
+		nextFork  bool
+		l1Message bool
+		wantGas   uint64
 	}{
 		{name: "pre next fork keeps legacy gas used", wantGas: legacyGas},
 		{name: "next fork clamps gas used to floor", nextFork: true, wantGas: floorGas},
+		{name: "next fork exempts l1 message from floor", nextFork: true, l1Message: true, wantGas: legacyGas},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := params.TestNoL1DataFeeChainConfig.Clone()
@@ -148,7 +150,23 @@ func TestTransitionDbNextForkFloorDataGasUsed(t *testing.T) {
 				To:       &to,
 				GasPrice: gasPrice,
 			}, statedb, cfg, vm.Config{})
-			msg := types.NewMessage(from, &to, 0, big.NewInt(0), gasLimit, gasPrice, gasPrice, gasPrice, 0, nil, 0, nil, nil, data, nil, nil, false)
+			var msg Message
+			if tt.l1Message {
+				tx := types.NewTx(&types.L1MessageTx{
+					QueueIndex: 1,
+					Gas:        gasLimit,
+					To:         &to,
+					Value:      big.NewInt(0),
+					Data:       data,
+					Sender:     from,
+				})
+				msg, err = tx.AsMessage(types.LatestSignerForChainID(cfg.ChainID), common.Big0)
+				if err != nil {
+					t.Fatalf("failed to convert L1 message tx: %v", err)
+				}
+			} else {
+				msg = types.NewMessage(from, &to, 0, big.NewInt(0), gasLimit, gasPrice, gasPrice, gasPrice, 0, nil, 0, nil, nil, data, nil, nil, false)
+			}
 			gp := new(GasPool).AddGas(gasLimit)
 			result, err := NewStateTransition(evm, msg, gp, big.NewInt(0)).TransitionDb()
 			if err != nil {
@@ -158,5 +176,49 @@ func TestTransitionDbNextForkFloorDataGasUsed(t *testing.T) {
 				t.Fatalf("UsedGas mismatch: got %d, want %d", result.UsedGas, tt.wantGas)
 			}
 		})
+	}
+}
+
+func TestRefundGasRecordsActualRefundAfterFloorClamp(t *testing.T) {
+	statedb, err := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	from := common.HexToAddress("0x1000000000000000000000000000000000000000")
+	to := common.HexToAddress("0x2000000000000000000000000000000000000000")
+	cfg := params.TestNoL1DataFeeChainConfig.Clone()
+	evm := vm.NewEVM(vm.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		BlockNumber: common.Big0,
+		Time:        common.Big0,
+		BaseFee:     common.Big0,
+	}, vm.TxContext{
+		Origin:   from,
+		To:       &to,
+		GasPrice: big.NewInt(1),
+	}, statedb, cfg, vm.Config{})
+	msg := types.NewMessage(from, &to, 0, big.NewInt(0), 100000, big.NewInt(1), big.NewInt(1), big.NewInt(1), 0, nil, 0, nil, nil, nil, nil, nil, false)
+
+	st := &StateTransition{
+		gp:           new(GasPool),
+		msg:          msg,
+		gas:          59000,
+		gasPrice:     big.NewInt(1),
+		initialGas:   100000,
+		floorDataGas: 71000,
+		state:        statedb,
+		evm:          evm,
+	}
+	st.state.AddRefund(10000)
+
+	st.refundGas(params.RefundQuotientEIP3529)
+
+	if st.gas != 29000 {
+		t.Fatalf("gas after floor clamp mismatch: got %d, want %d", st.gas, 29000)
+	}
+	if st.gasRefunded != 0 {
+		t.Fatalf("gasRefunded mismatch after floor clamp: got %d, want 0", st.gasRefunded)
 	}
 }

--- a/core/error.go
+++ b/core/error.go
@@ -89,6 +89,10 @@ var (
 	// than required to start the invocation.
 	ErrIntrinsicGas = errors.New("intrinsic gas too low")
 
+	// ErrFloorDataGas is returned if the transaction gas limit is below the
+	// EIP-7623 calldata floor.
+	ErrFloorDataGas = errors.New("floor data gas too low")
+
 	// ErrTxTypeNotSupported is returned if a transaction is not supported in the
 	// current network configuration.
 	ErrTxTypeNotSupported = types.ErrTxTypeNotSupported

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -150,6 +150,7 @@ type ChainOverrides struct {
 	ViridianTime *uint64
 	EmeraldTime  *uint64
 	JadeForkTime *uint64
+	NextForkTime *uint64
 }
 
 // apply applies the chain overrides on the supplied chain config.
@@ -168,6 +169,9 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 	}
 	if o.JadeForkTime != nil {
 		cfg.JadeForkTime = o.JadeForkTime
+	}
+	if o.NextForkTime != nil {
+		cfg.NextForkTime = o.NextForkTime
 	}
 	return cfg.CheckConfigForkOrder()
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -70,9 +70,9 @@ type StateTransition struct {
 	gasFeeCap  *big.Int
 	gasTipCap  *big.Int
 	initialGas uint64
-	// gasRefunded records the gas units returned by refundGas, so DoEstimateGas
-	// can recover the gross consumption (UsedGas+gasRefunded) for its optimistic
-	// gas-limit guess. Not consensus-relevant; never enters receipts or traces.
+	// gasRefunded records the gas units actually returned by refundGas after
+	// any settlement-time floors are applied. DoEstimateGas uses it for an
+	// optimistic gas-limit guess; it is not consensus-relevant.
 	gasRefunded  uint64
 	value        *big.Int
 	data         []byte
@@ -117,7 +117,7 @@ type ExecutionResult struct {
 	FeeRate     *big.Int
 	TokenScale  *big.Int
 	UsedGas     uint64 // Net gas used by the state transition (gross consumed minus refund applied)
-	RefundedGas uint64 // Gas refunded at settlement; UsedGas+RefundedGas equals the gross peak consumption
+	RefundedGas uint64 // Gas actually refunded at settlement after settlement-time floors
 	Err         error  // Any error encountered during the execution(listed in core/vm/errors.go)
 	ReturnData  []byte // Returned data from evm(function result or data supplied with revert opcode)
 }
@@ -699,16 +699,17 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 		refund = st.state.GetRefund()
 	}
 
-	if st.evm.Config.Tracer != nil && st.evm.Config.Tracer.OnGasChange != nil && refund > 0 {
-		st.evm.Config.Tracer.OnGasChange(st.gas, st.gas+refund, tracing.GasChangeTxRefunds)
-	}
-	// Record the finalized refund (gas units) for DoEstimateGas's optimistic
-	// guess. This does not alter the refund value, st.gas, or any balance below.
-	st.gasRefunded = refund
+	preRefundGas := st.gas
 	st.gas += refund
 
 	if st.floorDataGas > 0 && st.gasUsed() < st.floorDataGas {
 		st.gas = st.initialGas - st.floorDataGas
+	}
+	if st.gas > preRefundGas {
+		st.gasRefunded = st.gas - preRefundGas
+	}
+	if st.evm.Config.Tracer != nil && st.evm.Config.Tracer.OnGasChange != nil && st.gasRefunded > 0 {
+		st.evm.Config.Tracer.OnGasChange(preRefundGas, preRefundGas+st.gasRefunded, tracing.GasChangeTxRefunds)
 	}
 
 	// Return remaining gas to the block gas counter at the end, regardless of refund success

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -73,11 +73,12 @@ type StateTransition struct {
 	// gasRefunded records the gas units returned by refundGas, so DoEstimateGas
 	// can recover the gross consumption (UsedGas+gasRefunded) for its optimistic
 	// gas-limit guess. Not consensus-relevant; never enters receipts or traces.
-	gasRefunded uint64
-	value       *big.Int
-	data        []byte
-	state       vm.StateDB
-	evm         *vm.EVM
+	gasRefunded  uint64
+	value        *big.Int
+	data         []byte
+	floorDataGas uint64
+	state        vm.StateDB
+	evm          *vm.EVM
 
 	l1DataFee *big.Int
 
@@ -199,6 +200,22 @@ func IntrinsicGas(data []byte, accessList types.AccessList, authList []types.Set
 		gas += uint64(len(authList)) * params.CallNewAccountGas
 	}
 	return gas, nil
+}
+
+// FloorDataGas computes the EIP-7623 calldata floor gas for a message.
+func FloorDataGas(data []byte) (uint64, error) {
+	var (
+		z  = uint64(bytes.Count(data, []byte{0}))
+		nz = uint64(len(data)) - z
+	)
+	if (math.MaxUint64-z)/params.TxTokenPerNonZeroByte < nz {
+		return 0, ErrGasUintOverflow
+	}
+	tokens := nz*params.TxTokenPerNonZeroByte + z
+	if (math.MaxUint64-params.TxGas)/params.TxCostFloorPerToken < tokens {
+		return 0, ErrGasUintOverflow
+	}
+	return params.TxGas + tokens*params.TxCostFloorPerToken, nil
 }
 
 // toWordSize returns the ceiled word size required for init code payment calculation.
@@ -494,6 +511,12 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	if rules.IsNextFork && !st.msg.IsL1MessageTx() {
+		st.floorDataGas, err = FloorDataGas(st.data)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if st.gas < gas {
 		// Allow L1 message transactions to be included in the block but fail during execution,
 		// instead of rejecting them outright at this point.
@@ -502,6 +525,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		} else {
 			return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
 		}
+	}
+	if st.floorDataGas > 0 && st.gas < st.floorDataGas {
+		return nil, fmt.Errorf("%w: have %d, want %d", ErrFloorDataGas, st.gas, st.floorDataGas)
 	}
 	if t := st.evm.Config.Tracer; t != nil && t.OnGasChange != nil {
 		t.OnGasChange(st.gas, st.gas-gas, tracing.GasChangeTxIntrinsicGas)
@@ -680,6 +706,10 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 	// guess. This does not alter the refund value, st.gas, or any balance below.
 	st.gasRefunded = refund
 	st.gas += refund
+
+	if st.floorDataGas > 0 && st.gasUsed() < st.floorDataGas {
+		st.gas = st.initialGas - st.floorDataGas
+	}
 
 	// Return remaining gas to the block gas counter at the end, regardless of refund success
 	defer func() {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -258,6 +258,7 @@ type TxPool struct {
 	shanghai bool // Fork indicator whether we are in the Shanghai stage.
 	eip7702  bool // Fork indicator whether we are in the Morph 3.0.0 stage.
 	jade     bool // Fork indicator whether we are in the Jade stage.
+	nextFork bool // Fork indicator whether we are in the NextFork stage.
 
 	currentState  *state.StateDB // Current state in the blockchain head
 	currentHead   *big.Int       // Current blockchain head
@@ -807,6 +808,15 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	intrGas, err := IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, pool.istanbul, pool.shanghai)
 	if err != nil {
 		return err
+	}
+	if pool.nextFork {
+		floorGas, err := FloorDataGas(tx.Data())
+		if err != nil {
+			return err
+		}
+		if floorGas > intrGas {
+			intrGas = floorGas
+		}
 	}
 	if tx.Gas() < intrGas {
 		return ErrIntrinsicGas
@@ -1590,6 +1600,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.shanghai = pool.chainconfig.IsShanghai(next)
 	pool.eip7702 = pool.chainconfig.IsViridian(next, newHead.Time)
 	pool.jade = pool.chainconfig.IsJadeFork(newHead.Time)
+	pool.nextFork = pool.chainconfig.IsNextFork(newHead.Time)
 
 	// Remove MorphTx V1 transactions if jade fork is not active (e.g. after reorg)
 	if !pool.jade {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -139,6 +139,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverrideJadeForkTime != nil {
 		overrides.JadeForkTime = config.OverrideJadeForkTime
 	}
+	if config.OverrideNextForkTime != nil {
+		overrides.NextForkTime = config.OverrideNextForkTime
+	}
 	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, &overrides)
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -239,6 +239,9 @@ type Config struct {
 
 	// JadeForkTime override
 	OverrideJadeForkTime *uint64 `toml:",omitempty"`
+
+	// NextForkTime override
+	OverrideNextForkTime *uint64 `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -70,6 +70,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		OverrideMorph203Time    *uint64 `toml:",omitempty"`
 		OverrideMorph300Time    *uint64 `toml:",omitempty"`
 		OverrideEmeraldTime     *uint64 `toml:",omitempty"`
+		OverrideJadeForkTime    *uint64 `toml:",omitempty"`
+		OverrideNextForkTime    *uint64 `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -124,6 +126,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.OverrideMorph203Time = c.OverrideMorph203Time
 	enc.OverrideMorph300Time = c.OverrideViridianTime
 	enc.OverrideEmeraldTime = c.OverrideEmeraldTime
+	enc.OverrideJadeForkTime = c.OverrideJadeForkTime
+	enc.OverrideNextForkTime = c.OverrideNextForkTime
 	return &enc, nil
 }
 
@@ -182,6 +186,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		OverrideMorph203Time    *uint64 `toml:",omitempty"`
 		OverrideViridianTime    *uint64 `toml:",omitempty"`
 		OverrideEmeraldTime     *uint64 `toml:",omitempty"`
+		OverrideJadeForkTime    *uint64 `toml:",omitempty"`
+		OverrideNextForkTime    *uint64 `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -342,6 +348,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideEmeraldTime != nil {
 		c.OverrideEmeraldTime = dec.OverrideEmeraldTime
+	}
+	if dec.OverrideJadeForkTime != nil {
+		c.OverrideJadeForkTime = dec.OverrideJadeForkTime
+	}
+	if dec.OverrideNextForkTime != nil {
+		c.OverrideNextForkTime = dec.OverrideNextForkTime
 	}
 	return nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -657,6 +657,7 @@ func (api *PublicBlockChainAPI) ChainId() (*hexutil.Big, error) {
 type morphExtension struct {
 	UseZktrie    bool    `json:"useZktrie"`
 	JadeForkTime *uint64 `json:"jadeForkTime,omitempty"`
+	NextForkTime *uint64 `json:"nextForkTime,omitempty"`
 }
 
 // config represents a single fork configuration (EIP-7910)
@@ -720,6 +721,7 @@ func (api *PublicBlockChainAPI) Config(ctx context.Context) (*configResponse, er
 		morph := &morphExtension{
 			UseZktrie:    c.Morph.UseZktrie,
 			JadeForkTime: c.JadeForkTime,
+			NextForkTime: c.NextForkTime,
 		}
 
 		return &config{

--- a/les/client.go
+++ b/les/client.go
@@ -102,6 +102,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	if config.OverrideJadeForkTime != nil {
 		overrides.JadeForkTime = config.OverrideJadeForkTime
 	}
+	if config.OverrideNextForkTime != nil {
+		overrides.NextForkTime = config.OverrideNextForkTime
+	}
 	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, &overrides)
 	if _, isCompat := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -74,6 +74,7 @@ type TxPool struct {
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
 	eip2718  bool // Fork indicator whether we are in the eip2718 stage.
 	shanghai bool // Fork indicator whether we are in the shanghai stage.
+	nextFork bool // Fork indicator whether we are in the NextFork stage.
 
 	currentHead    *big.Int // Current blockchain head
 	getBalanceFunc func(header *types.Header, state *state.StateDB, tokenID uint16, addr common.Address) (*big.Int, error)
@@ -351,6 +352,7 @@ func (pool *TxPool) setNewHead(head *types.Header) {
 	pool.istanbul = pool.config.IsIstanbul(next)
 	pool.eip2718 = pool.config.IsBerlin(next)
 	pool.shanghai = pool.config.IsShanghai(next)
+	pool.nextFork = pool.config.IsNextFork(head.Time)
 
 	pool.currentHead = next
 }
@@ -493,6 +495,15 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, pool.istanbul, pool.shanghai)
 	if err != nil {
 		return err
+	}
+	if pool.nextFork {
+		floorGas, err := core.FloorDataGas(tx.Data())
+		if err != nil {
+			return err
+		}
+		if floorGas > gas {
+			gas = floorGas
+		}
 	}
 	if tx.Gas() < gas {
 		return core.ErrIntrinsicGas

--- a/params/config.go
+++ b/params/config.go
@@ -858,6 +858,9 @@ func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64, time u
 // CheckConfigForkOrder checks that we don't "skip" any forks, geth isn't pluggable enough
 // to guarantee that forks can be implemented in a different order than on official networks
 func (c *ChainConfig) CheckConfigForkOrder() error {
+	if c.NextForkTime != nil && c.JadeForkTime == nil {
+		return fmt.Errorf("unsupported fork ordering: nextForkTime set, but jadeForkTime not enabled")
+	}
 	type fork struct {
 		name      string
 		block     *big.Int

--- a/params/config.go
+++ b/params/config.go
@@ -563,6 +563,7 @@ type ChainConfig struct {
 	ViridianTime        *uint64  `json:"viridianTime,omitempty"`        // ViridianTime switch time (nil = no fork, 0 = already on viridian)
 	EmeraldTime         *uint64  `json:"emeraldTime,omitempty"`         // EmeraldTime switch time (nil = no fork, 0 = already on emerald)
 	JadeForkTime        *uint64  `json:"jadeForkTime,omitempty"`        // JadeForkTime switch time (nil = no fork). State backend is always MPT; Jade is only a historical epoch boundary: pre-Jade headers carry legacy zkTrie state roots and skip state-root validation, post-Jade headers are native MPT.
+	NextForkTime        *uint64  `json:"nextForkTime,omitempty"`        // NextForkTime switch time (nil = no fork, 0 = already on next fork)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -680,7 +681,7 @@ func (c *ChainConfig) String() string {
 		engine = "unknown"
 	}
 	return fmt.Sprintf(
-		"{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Archimedes: %v, Shanghai: %v, Bernoulli: %v, Curie: %v, Morph203: %v, Viridian: %v, Emerald: %v, JadeFork: %v, Engine: %v, Morph config: %v}",
+		"{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Archimedes: %v, Shanghai: %v, Bernoulli: %v, Curie: %v, Morph203: %v, Viridian: %v, Emerald: %v, JadeFork: %v, NextFork: %v, Engine: %v, Morph config: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -704,6 +705,7 @@ func (c *ChainConfig) String() string {
 		c.ViridianTime,
 		c.EmeraldTime,
 		c.JadeForkTime,
+		c.NextForkTime,
 		engine,
 		c.Morph,
 	)
@@ -815,6 +817,11 @@ func (c *ChainConfig) IsJadeFork(time uint64) bool {
 	return isTimestampForked(c.JadeForkTime, time)
 }
 
+// IsNextFork returns whether the given time is at or after the NextFork time.
+func (c *ChainConfig) IsNextFork(time uint64) bool {
+	return c.IsJadeFork(time) && isTimestampForked(c.NextForkTime, time)
+}
+
 // IsTerminalPoWBlock returns whether the given block is the last block of PoW stage.
 func (c *ChainConfig) IsTerminalPoWBlock(parentTotalDiff *big.Int, totalDiff *big.Int) bool {
 	if c.TerminalTotalDifficulty == nil {
@@ -880,6 +887,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "viridianTime", timestamp: c.ViridianTime, optional: true},
 		{name: "emeraldTime", timestamp: c.EmeraldTime, optional: true},
 		{name: "jadeForkTime", timestamp: c.JadeForkTime, optional: true},
+		{name: "nextForkTime", timestamp: c.NextForkTime, optional: true},
 	} {
 		if lastFork.name != "" {
 			switch {
@@ -991,6 +999,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int, headTi
 	}
 	if isForkTimestampIncompatible(c.JadeForkTime, newcfg.JadeForkTime, headTimestamp) {
 		return newTimestampCompatError("JadeForkTime fork timestamp", c.JadeForkTime, newcfg.JadeForkTime)
+	}
+	if isForkTimestampIncompatible(c.NextForkTime, newcfg.NextForkTime, headTimestamp) {
+		return newTimestampCompatError("NextForkTime fork timestamp", c.NextForkTime, newcfg.NextForkTime)
 	}
 	return nil
 }
@@ -1139,6 +1150,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul   bool
 	IsBerlin, IsLondon, IsArchimedes, IsShanghai, IsBernoulli bool
 	IsCurie, IsMorph203, IsViridian, IsEmerald, IsJadeFork    bool
+	IsNextFork                                                bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1167,6 +1179,7 @@ func (c *ChainConfig) Rules(num *big.Int, time uint64) Rules {
 		IsViridian:       c.IsViridian(num, time),
 		IsEmerald:        c.IsEmerald(num, time),
 		IsJadeFork:       c.IsJadeFork(time),
+		IsNextFork:       c.IsNextFork(time),
 	}
 }
 
@@ -1176,6 +1189,10 @@ func (c *ChainConfig) Rules(num *big.Int, time uint64) Rules {
 // We only check timestamp-based conditions here.
 func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
 	switch {
+	case c.IsNextFork(time):
+		return forks.NextFork
+	case isTimestampForked(c.JadeForkTime, time):
+		return forks.JadeFork
 	case isTimestampForked(c.EmeraldTime, time):
 		return forks.Emerald
 	case isTimestampForked(c.ViridianTime, time):
@@ -1193,6 +1210,10 @@ func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
 // the fork isn't defined or isn't a time-based fork.
 func (c *ChainConfig) Timestamp(fork forks.Fork) *uint64 {
 	switch fork {
+	case forks.NextFork:
+		return c.NextForkTime
+	case forks.JadeFork:
+		return c.JadeForkTime
 	case forks.Emerald:
 		return c.EmeraldTime
 	case forks.Viridian:

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -139,6 +139,16 @@ func TestConfigRules(t *testing.T) {
 	}
 }
 
+func TestCheckConfigForkOrderRequiresJadeForNextFork(t *testing.T) {
+	cfg := AllEthashProtocolChanges.Clone()
+	cfg.NextForkTime = NewUint64(10)
+	cfg.JadeForkTime = nil
+	require.ErrorContains(t, cfg.CheckConfigForkOrder(), "nextForkTime set, but jadeForkTime not enabled")
+
+	cfg.JadeForkTime = NewUint64(9)
+	require.NoError(t, cfg.CheckConfigForkOrder())
+}
+
 func TestTimestampCompatError(t *testing.T) {
 	require.Equal(t, new(ConfigCompatError).Error(), "")
 

--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -41,6 +41,8 @@ const (
 	Morph203
 	Viridian
 	Emerald
+	JadeFork
+	NextFork
 )
 
 // String implements fmt.Stringer.
@@ -74,4 +76,6 @@ var forkToString = map[Fork]string{
 	Morph203:         "Morph203",
 	Viridian:         "Viridian",
 	Emerald:          "Emerald",
+	JadeFork:         "JadeFork",
+	NextFork:         "NextFork",
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -88,6 +88,8 @@ const (
 
 	TxDataNonZeroGasFrontier  uint64 = 68    // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions.
 	TxDataNonZeroGasEIP2028   uint64 = 16    // Per byte of non zero data attached to a transaction after EIP 2028 (part in Istanbul)
+	TxTokenPerNonZeroByte     uint64 = 4     // Per non-zero calldata byte token weight after EIP-7623
+	TxCostFloorPerToken       uint64 = 10    // Per calldata token floor gas cost after EIP-7623
 	TxAccessListAddressGas    uint64 = 2400  // Per address specified in EIP 2930 access list
 	TxAccessListStorageKeyGas uint64 = 1900  // Per storage key specified in EIP 2930 access list
 	TxAuthTupleGas            uint64 = 12500 // Per auth tuple code specified in EIP-7702

--- a/tests/init.go
+++ b/tests/init.go
@@ -351,6 +351,33 @@ var Forks = map[string]*params.ChainConfig{
 			FeeVaultAddress: &params.MorphFeeVaultAddress,
 		},
 	},
+	"NextFork": {
+		ChainID:             big.NewInt(1),
+		HomesteadBlock:      big.NewInt(0),
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		ArrowGlacierBlock:   big.NewInt(0),
+		ArchimedesBlock:     big.NewInt(0),
+		ShanghaiBlock:       big.NewInt(0),
+		BernoulliBlock:      big.NewInt(0),
+		CurieBlock:          big.NewInt(0),
+		Morph203Time:        new(uint64),
+		ViridianTime:        new(uint64),
+		EmeraldTime:         new(uint64),
+		JadeForkTime:        new(uint64),
+		NextForkTime:        new(uint64),
+		Morph: params.MorphConfig{
+			FeeVaultAddress: &params.MorphFeeVaultAddress,
+		},
+	},
 }
 
 // Returns the set of defined fork names

--- a/tests/state_test_morph_test.go
+++ b/tests/state_test_morph_test.go
@@ -48,7 +48,7 @@ const morphMinimalStateTest = `{
 }`
 
 func TestMorphForkNamesAreAvailableForStateTests(t *testing.T) {
-	for _, fork := range []string{"Bernoulli", "Curie", "Morph203", "Viridian", "Emerald", "Jade"} {
+	for _, fork := range []string{"Bernoulli", "Curie", "Morph203", "Viridian", "Emerald", "Jade", "NextFork"} {
 		if _, _, err := GetChainConfig(fork); err != nil {
 			t.Fatalf("expected fork %s to be available: %v", fork, err)
 		}


### PR DESCRIPTION
## Summary
- Add NextFork-gated EIP-7623 calldata floor gas accounting for txpool admission and execution receipts.
- Keep legacy intrinsic gas deduction intact and clamp gas used after refund accounting so refunds, gas pool, and fee recipient accounting stay consistent.
- Add NextFork config plumbing, override flags, RPC config exposure, and focused tests for the X18 calldata-floor boundary.
- Address CodeRabbit feedback by enforcing NextFork/Jade config dependency, recording actual refunded gas after floor clamps, and covering L1 message exemption.

## Test plan
- go test ./core -run 'TestFloorDataGas|TestTxPoolNextForkFloorDataGas|TestTransitionDbNextForkFloorDataGasUsed|TestRefundGasRecordsActualRefundAfterFloorClamp'
- go test ./params
- go test ./internal/ethapi -run '^$'
- go test ./eth/ethconfig -run '^$'
- go test ./cmd/geth ./light ./les -run '^$'
- go test ./tests -run TestMorphForkNamesAreAvailableForStateTests
- git diff --check

Closes #339