### PR TITLE
fix(node): enforce JWT auth on the authenticated WebSocket endpoint

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -329,7 +329,7 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig) error {
 	}
 	h.wsConfig = config
 	h.wsHandler.Store(&rpcHandler{
-		Handler: srv.WebsocketHandler(config.Origins),
+		Handler: NewWSHandlerStack(srv.WebsocketHandler(config.Origins), config.jwtSecret),
 		server:  srv,
 	})
 	return nil
@@ -382,6 +382,18 @@ func NewHTTPHandlerStack(srv http.Handler, cors []string, vhosts []string, jwtSe
 		handler = newJWTHandler(jwtSecret, handler)
 	}
 	return newGzipHandler(handler)
+}
+
+// NewWSHandlerStack returns a wrapped ws-related handler. When a JWT secret is
+// configured (as it is for the authenticated Engine API endpoint) the handshake
+// is gated on JWT validation, matching the protection applied to the HTTP path
+// in NewHTTPHandlerStack. Without this the authenticated WebSocket listener
+// would serve Engine API methods with no token check.
+func NewWSHandlerStack(srv http.Handler, jwtSecret []byte) http.Handler {
+	if len(jwtSecret) != 0 {
+		return newJWTHandler(jwtSecret, srv)
+	}
+	return srv
 }
 
 func newCorsHandler(srv http.Handler, allowedOrigins []string) http.Handler {


### PR DESCRIPTION
## Summary

The authenticated RPC listener (`--authrpc.addr` / `--authrpc.port`, default `localhost:8551`) enforces JWT on the **HTTP** path but **not** on the **WebSocket** path. An attacker able to reach the auth WS listener can invoke authenticated Engine API methods (e.g. `engine_setBlockTags`, which mutates the node's local safe/finalized tags) **without a valid JWT**.

## Root cause

- `enableRPC` wraps the handler with `NewHTTPHandlerStack(srv, …, config.jwtSecret)` → HTTP path is JWT-gated. ✅
- `enableWS` stored the raw `srv.WebsocketHandler(config.Origins)` with **no** JWT wrapper; `config.jwtSecret` was passed in by `initAuth` but never used. ❌
- `httpServer.ServeHTTP` routes WebSocket upgrades directly to the WS handler, so the JWT check on the HTTP handler is never reached.

This fork branched **before** upstream go-ethereum's JWT feature and re-implemented JWT only for the HTTP path, omitting upstream's `NewWSHandlerStack` for the WS handshake. Upstream geth gates **both** paths, so upstream-tracking nodes are not affected — this is a Morph-specific gap.

## Upstream reference (official go-ethereum)

This PR simply re-aligns with how upstream already does it:

- JWT feature PR: [ethereum/go-ethereum#24364](https://github.com/ethereum/go-ethereum/pull/24364) — *"cmd/geth, node, rpc: implement jwt tokens"*
- `enableWS` wraps the WS handler with JWT upstream: [node/rpcstack.go#L362](https://github.com/ethereum/go-ethereum/blob/68f711b9defc53cb1b29cf0a1c65a32bbed10254/node/rpcstack.go#L362)
- `NewWSHandlerStack` definition upstream: [node/rpcstack.go#L422](https://github.com/ethereum/go-ethereum/blob/68f711b9defc53cb1b29cf0a1c65a32bbed10254/node/rpcstack.go#L422)

## Fix

Reintroduce `NewWSHandlerStack` and apply it in `enableWS`, mirroring `NewHTTPHandlerStack` and upstream behavior. When no JWT secret is configured (legacy public WS) the handler is returned unchanged, so non-auth WS is unaffected.

## Evidence / tests

The existing `TestJWT` already asserts bad tokens must be **rejected over WebSocket**. Those WS cases were **failing on `main`** (every invalid/forged/missing token returned `got ok`) and **pass** with this change. HTTP cases were unaffected.

```
# before (main): TestJWT → FAIL (tc N-ws … expected not to allow, got ok)
# after (this PR): TestJWT → ok
```

Note: `TestWebsocketOrigins` currently panics (`odd extraHeaders length`) on `main` independently of this change — pre-existing test-helper bug, out of scope here but worth a follow-up.

## Severity note

By default the auth listener binds to `localhost`, so this is a local-process auth bypass in default deployments; it becomes remotely exploitable if the auth listener is bound to a reachable interface (`0.0.0.0`) or exposed via a proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)