### PR TITLE
snapshot: calibrate aggregatorMemoryLimit for Morph's state write rate

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -40,7 +40,26 @@ var (
 	// Note, bumping this up might drastically increase the size of the bloom
 	// filters that's stored in every diff layer. Don't do that without fully
 	// understanding all the implications.
-	aggregatorMemoryLimit = uint64(4 * 1024 * 1024)
+	//
+	// Morph note: upstream's 4MiB was calibrated for mainnet, which generates
+	// tens of KiB of state diff per block and therefore fills the aggregator in
+	// ~42 blocks, keeping the disk layer within ~250 blocks of the head. Morph
+	// writes state orders of magnitude slower (a low-traffic chain can sit at a
+	// few bytes per second), so 4MiB takes days to fill and the disk layer falls
+	// hundreds of thousands of blocks behind the head.
+	//
+	// That matters because setHeadBeyondRoot uses the snapshot disk layer root
+	// as a hard rewind threshold (see core/blockchain.go, "Make sure the rewound
+	// point is lower than disk layer"). Once the lag exceeds
+	// params.FullImmutabilityThreshold, an unclean-shutdown repair rewinds past
+	// the freezer cutoff, which forces per-block ancient truncation instead of
+	// upstream's cheap "don't touch the header chain" repair path.
+	//
+	// 32KiB keeps the lag comfortably below the freezer cutoff at Morph's block
+	// rates while still flushing the disk layer only about once an hour. It also
+	// shrinks every diff layer's bloom filter, since bloomSize is derived from
+	// aggregatorItemLimit below.
+	aggregatorMemoryLimit = uint64(32 * 1024)
 
 	// aggregatorItemLimit is an approximate number of items that will end up
 	// in the agregator layer before it's flushed out to disk. A plain account


### PR DESCRIPTION
## Problem

`aggregatorMemoryLimit` (4MiB) gates when the snapshot **disk layer** advances. It is a *byte* threshold, calibrated for mainnet — which produces tens of KiB of state diff per block and fills the aggregator in ~42 blocks, keeping the disk layer within a few hundred blocks of the head.

Morph writes state orders of magnitude more slowly. On a low-traffic chain the rate is a few bytes per second, so 4MiB takes **days** to fill and the disk layer falls hundreds of thousands of blocks behind.

That matters because `setHeadBeyondRoot` uses the snapshot disk layer root as a **hard rewind threshold** (`core/blockchain.go`: *"Make sure the rewound point is lower than disk layer"*). Blocks that still have valid state are skipped (`Skipping block with threshold state`) until the walk crosses that root — so **the lag becomes the rewind depth of any unclean-shutdown repair**.

## Observed incident (hoodi full node, 2026-08-13)

```
WARN [08-13|11:27:31.394] Head state missing, repairing  number=7,509,671 snaproot=eb2fab..f4528f
DEBUG[08-13|11:27:46.927] Rewound to block with state    number=7,223,430
```

`7,509,671 − 7,223,430 = 286,241` blocks of lag — far past `params.FullImmutabilityThreshold` (90,000). That flips `wipe` to `true` in `updateFn`, so `NewBlockChain` takes

```go
if repair {
    if target, force := updateFn(...); force {   // force == wipe
        bc.hc.SetHead(target, updateFn, delFn)
    }
}
```

instead of upstream's intended *"try to skip touching the header chain altogether, unless the freezer is broken"* path. `delFn` then calls `TruncateAncients` **once per block** — 196,241 irreversible truncations over ~11 minutes, during which the freezer and the KV store are inconsistent (ancient truncation is durable immediately; the header/TD/body deletions sit in a batch until `headerchain.go` flushes it at the end).

## Fix

Recalibrate the constant for Morph's write rate. **No logic change** — this keeps `core/blockchain.go` byte-identical to upstream and returns `repair` to the non-destructive branch upstream already takes on mainnet.

| `aggregatorMemoryLimit` | itemLimit | total lag @2s | total lag @300ms | vs 90,000 |
|---|---|---|---|---|
| 4MiB (current) | 99,864 | ~301,000 (measured 286,241) | ~2,010,000 | 22× over |
| 128KiB | 3,120 | ~11,300 | ~75,200 | 1.2× margin |
| **32KiB (this PR)** | **780** | **~4,260** | **~28,400** | **3.2× margin** |

Total lag = (128-layer window) + (aggregator). 32KiB is the knee: the aggregator segment (~15,600 blocks @300ms) roughly equals the irreducible 128-layer window floor (~12,800 blocks), so going lower yields little.

### Costs

- `diffToDisk` runs more often, but total bytes written are unchanged — only batched more finely. At current throughput the disk layer still flushes about once an hour.
- Every diff layer's bloom filter **shrinks** from ~99KiB to ~0.8KiB (`bloomSize` derives from `aggregatorItemLimit`) — ~12MiB less memory across 128 layers. Verified non-degenerate: `bloomSize=6352 bit`, `bloomFuncs=6`.
- The comment in this var block warns only about *raising* the limit (bloom growth); lowering moves the opposite way.

## Testing

| Check | Result |
|---|---|
| `gofmt` | pass |
| `go build ./...` | pass |
| `core/state/snapshot`, non-`TestGenerat*` (28 tests) | **all pass** |
| `TestGenerat*` (13 tests) | pre-existing failure — identical output on `main` (same root mismatch / same panic) |
| `core` `TestShortRepair*` / `TestShortSetHead*` | pre-existing failure — byte-identical output on `main` |

Existing tests already save/restore `aggregatorMemoryLimit` (`snapshot_test.go`, `iterator_test.go` set it to `0`), so the default change does not affect them.

**This PR introduces no new test failures.** The `generate_test.go` and `core` repair/setHead failures reproduce on unmodified `main` and are out of scope here.

## Verification plan before marking ready

Unit tests cannot show "the rewind got shallower". On a canary node:

```bash
kill -9 <geth-pid>
grep -E "Head state missing, repairing|Rewound to block with state" geth.log
```

`head − (Rewound to block with state)` is the actual rewind depth. Expected: hundreds of thousands before, under ~30k after. Will attach before/after numbers.

## Not in this PR

- `params.FullImmutabilityThreshold` 90,000 → 540,000 (restores upstream's 12.5-day semantics at Morph's block time). Deliberately excluded: that constant also feeds `fullMaxForkAncestry` in `eth/downloader` and `les/downloader`, plus clique's snapshot trust limit, so it needs its own usage audit. 32KiB alone gives 3.2× margin.
- Shutdown-grace / monitoring changes (deployment config, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
